### PR TITLE
metrics endpoint access restricted

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,3 +93,12 @@ INDEXED_CONTRACTS='[]'
 # ==============================================
 # Used for user/wallet management (separate from TypeORM)
 DATABASE_URL=file:./dev.db
+
+# ==============================================
+# Metrics Configuration
+# ==============================================
+# Prometheus metrics endpoint protection
+# Set a bearer token to restrict access to /metrics endpoint
+# Leave empty to allow public access (not recommended for production)
+# Generate a secure token: openssl rand -hex 32
+METRICS_TOKEN=

--- a/METRICS_SECURITY.md
+++ b/METRICS_SECURITY.md
@@ -1,0 +1,136 @@
+# Metrics Endpoint Security Implementation
+
+## Overview
+The `/metrics` endpoint (Prometheus metrics) has been secured with bearer token authentication to prevent unauthorized access to operational data.
+
+## Changes Made
+
+### 1. Created Metrics Authentication Guard
+**File:** `src/metrics/metrics-auth.guard.ts`
+
+This guard implements bearer token authentication for the metrics endpoint:
+- Reads the `METRICS_TOKEN` environment variable
+- If the token is not set, access is allowed (backward compatibility for development)
+- If the token is set, requires a valid `Authorization: Bearer <token>` header
+- Returns 401 Unauthorized for invalid or missing tokens
+
+### 2. Created Metrics Module
+**File:** `src/metrics/metrics.module.ts`
+
+Properly encapsulates the metrics functionality as a NestJS module.
+
+### 3. Updated Metrics Controller
+**File:** `src/metrics/metrics.controller.ts`
+
+Applied the `@UseGuards(MetricsAuthGuard)` decorator to protect the endpoint.
+
+### 4. Updated App Module
+**File:** `src/app.module.ts`
+
+Imported `MetricsModule` to register the metrics controller and service.
+
+### 5. Updated Environment Configuration
+**File:** `.env.example`
+
+Added documentation for the `METRICS_TOKEN` environment variable with usage instructions.
+
+## Configuration
+
+### Environment Variable
+
+Add this to your `.env` file:
+
+```bash
+# Generate a secure token: openssl rand -hex 32
+METRICS_TOKEN=your_secure_token_here
+```
+
+### Generating a Secure Token
+
+```bash
+# Using OpenSSL
+openssl rand -hex 32
+
+# Using Node.js
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+## Usage
+
+### With Token (Production)
+
+```bash
+# Access metrics with authentication
+curl -H "Authorization: Bearer your_secure_token_here" http://localhost:3000/metrics
+```
+
+### Without Token (Development Only)
+
+If `METRICS_TOKEN` is not set in the environment, the endpoint allows public access for backward compatibility during development.
+
+**⚠️ Warning:** Always set `METRICS_TOKEN` in production environments.
+
+## Prometheus Configuration
+
+Update your Prometheus configuration to include the bearer token:
+
+```yaml
+scrape_configs:
+  - job_name: 'truthbounty-api'
+    metrics_path: '/metrics'
+    bearer_token: 'your_secure_token_here'
+    static_configs:
+      - targets: ['localhost:3000']
+```
+
+## Security Benefits
+
+1. **Prevents Information Leakage**: Operational metrics are no longer publicly accessible
+2. **Reconnaissance Protection**: Attackers cannot gather system performance data
+3. **Authorized Access Only**: Only authorized Prometheus scrapers can access metrics
+4. **Backward Compatible**: Development environments can still access metrics without token
+
+## Testing
+
+### Test with valid token:
+```bash
+curl -H "Authorization: Bearer your_token" http://localhost:3000/metrics
+# Should return metrics data
+```
+
+### Test without token (when METRICS_TOKEN is set):
+```bash
+curl http://localhost:3000/metrics
+# Should return: {"statusCode": 401, "message": "Missing authorization header"}
+```
+
+### Test with invalid token:
+```bash
+curl -H "Authorization: Bearer wrong_token" http://localhost:3000/metrics
+# Should return: {"statusCode": 401, "message": "Invalid metrics token"}
+```
+
+## Alternative: IP-Based Restriction
+
+For deployment environments that support it, you can also restrict access by IP address at the network level (e.g., using nginx, AWS Security Groups, or Kubernetes Network Policies) in addition to token-based authentication.
+
+### Example: Nginx Configuration
+
+```nginx
+location /metrics {
+    allow 10.0.0.0/8;  # Internal network only
+    deny all;
+    
+    proxy_pass http://localhost:3000/metrics;
+}
+```
+
+## Production Checklist
+
+- [ ] Generate a strong `METRICS_TOKEN` (at least 32 bytes)
+- [ ] Add `METRICS_TOKEN` to production environment variables
+- [ ] Update Prometheus scrape configuration with bearer token
+- [ ] Test metrics access with token
+- [ ] Verify public access is denied without token
+- [ ] (Optional) Add IP-based restrictions at network level
+- [ ] Monitor unauthorized access attempts via audit logs

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { ThemeModule } from './theme.module';
 import { AuditLoggingInterceptor } from './audit/interceptors/audit-logging.interceptor';
 import { LoggerModule } from './logger/logger.module';
 import { LoggingInterceptor } from './logger/logging.interceptor';
+import { MetricsModule } from './metrics/metrics.module';
 
 // In-memory storage for development (no Redis needed)
 class ThrottlerMemoryStorage {
@@ -203,6 +204,7 @@ async function createThrottlerStorage(configService: ConfigService): Promise<any
     ClaimsModule,
     AuditModule,
     ThemeModule,
+    MetricsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/metrics/metrics-auth.guard.ts
+++ b/src/metrics/metrics-auth.guard.ts
@@ -1,0 +1,37 @@
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+
+@Injectable()
+export class MetricsAuthGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const metricsToken = this.configService.get<string>('METRICS_TOKEN');
+
+    // If no token is configured, allow access (for backward compatibility)
+    if (!metricsToken) {
+      return true;
+    }
+
+    // Check for Bearer token in Authorization header
+    const authHeader = request.headers.authorization;
+    
+    if (!authHeader) {
+      throw new UnauthorizedException('Missing authorization header');
+    }
+
+    const [scheme, token] = authHeader.split(' ');
+
+    if (scheme !== 'Bearer' || !token) {
+      throw new UnauthorizedException('Invalid authorization scheme. Use Bearer token');
+    }
+
+    if (token !== metricsToken) {
+      throw new UnauthorizedException('Invalid metrics token');
+    }
+
+    return true;
+  }
+}

--- a/src/metrics/metrics.controller.ts
+++ b/src/metrics/metrics.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get, Res } from "@nestjs/common";
+import { Controller, Get, Res, UseGuards } from "@nestjs/common";
 import { Response } from "express";
 import { MetricsService } from "./metrics.service";
+import { MetricsAuthGuard } from "./metrics-auth.guard";
 
 @Controller("metrics")
+@UseGuards(MetricsAuthGuard)
 export class MetricsController {
   constructor(private readonly service: MetricsService) {}
 

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
+
+@Module({
+  controllers: [MetricsController],
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
+export class MetricsModule {}


### PR DESCRIPTION
I've successfully secured the /metrics endpoint with bearer token authentication. Here's what was implemented:
Changes Made:
Created [metrics-auth.guard.ts] - Authentication guard that validates Bearer tokens
Created [metrics.module.ts]- Proper NestJS module structure for metrics
Updated [metrics.controller.ts]- Added @UseGuards(MetricsAuthGuard) to protect the endpoint
Updated [app.module.ts]- Imported MetricsModule
Updated [.env.example] - Added METRICS_TOKEN configuration with documentation
Created [METRICS_SECURITY.md - Comprehensive documentation
How It Works:
Development: If METRICS_TOKEN is not set, the endpoint allows public access (backward compatible)
Production: Set METRICS_TOKEN in your environment to require Authorization: Bearer <token> header
Invalid/missing tokens return 401 Unauthorized

closes #85 