### PR TITLE
Fix dispute validation and Worldcoin verification

### DIFF
--- a/src/bootstrap.spec.ts
+++ b/src/bootstrap.spec.ts
@@ -1,0 +1,46 @@
+import { ValidationPipe } from '@nestjs/common';
+import { configureApp } from './bootstrap';
+
+jest.mock('@nestjs/swagger', () => {
+  const actual = jest.requireActual('@nestjs/swagger');
+  return {
+    ...actual,
+    SwaggerModule: {
+      createDocument: jest.fn().mockReturnValue({}),
+      setup: jest.fn(),
+    },
+  };
+});
+
+describe('configureApp', () => {
+  it('registers a single strict global validation pipe', () => {
+    const httpAdapter = { set: jest.fn() };
+    const app = {
+      useLogger: jest.fn(),
+      get: jest.fn(),
+      getHttpAdapter: jest.fn().mockReturnValue({ getInstance: () => httpAdapter }),
+      useGlobalPipes: jest.fn(),
+    } as any;
+
+    configureApp(app);
+
+    expect(app.useGlobalPipes).toHaveBeenCalledTimes(1);
+
+    const [pipe] = app.useGlobalPipes.mock.calls[0];
+    const validationPipe = pipe as ValidationPipe & {
+      validatorOptions?: Record<string, unknown>;
+      transformOptions?: Record<string, unknown>;
+      isTransformEnabled?: boolean;
+    };
+
+    expect(validationPipe).toBeInstanceOf(ValidationPipe);
+    expect(validationPipe.validatorOptions).toMatchObject({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(validationPipe.isTransformEnabled).toBe(true);
+    expect(validationPipe.transformOptions).toMatchObject({
+      enableImplicitConversion: true,
+    });
+  });
+});

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,63 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { Logger } from 'nestjs-pino';
+
+export function createGlobalValidationPipe() {
+  return new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+    transformOptions: {
+      enableImplicitConversion: true,
+    },
+  });
+}
+
+export function configureApp(app: INestApplication) {
+  app.useLogger(app.get(Logger));
+
+  const httpAdapter = app.getHttpAdapter().getInstance();
+
+  const trustedProxies =
+    process.env.TRUSTED_PROXIES?.split(',')?.map((ip) => ip.trim()) || [];
+  if (trustedProxies.length > 0) {
+    httpAdapter.set('trust proxy', trustedProxies);
+  } else {
+    httpAdapter.set('trust proxy', false);
+  }
+
+  app.useGlobalPipes(createGlobalValidationPipe());
+
+  const config = new DocumentBuilder()
+    .setTitle('TruthBounty API')
+    .setDescription('## Decentralized News Verification Infrastructure\n\nThis API provides endpoints for managing claims, disputes, identity verification, rewards, and blockchain event indexing.\n\n### API Version\n- **Version**: 1.0\n- **Base Path**: `/`\n\n### Authentication\nMost mutating endpoints (POST, PATCH, PUT, DELETE) require authentication using wallet signature-based JWT tokens.\n\n#### Authentication Flow:\n1. Request a challenge: `POST /auth/challenge` with your wallet address\n2. Sign the challenge message with your wallet\n3. Login: `POST /auth/login` with address, signature, and message\n4. Use the returned JWT token in the `Authorization` header as `Bearer <token>`\n\nRead-only endpoints (GET) remain public unless specifically protected.\n\n### Rate Limiting\nSome endpoints are rate-limited using wallet-based throttling.')
+    .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'JWT',
+        description: 'Enter JWT token',
+        in: 'header',
+      },
+      'JWT-auth',
+    )
+    .addTag('auth', 'Authentication with wallet signature')
+    .addTag('identity', 'User and wallet identity management')
+    .addTag('worldcoin', 'Worldcoin ID verification')
+    .addTag('claims', 'Claim management and evidence')
+    .addTag('evidence', 'Evidence management with flagging')
+    .addTag('disputes', 'Dispute creation and resolution')
+    .addTag('sybil', 'Sybil resistance scoring')
+    .addTag('blockchain', 'Blockchain event indexing and state')
+    .addTag('indexer', 'Event indexer management')
+    .addTag('rewards', 'Reward management')
+    .addTag('leaderboard', 'User leaderboard rankings')
+    .addTag('audit', 'Audit log retrieval')
+    .addTag('health', 'Health check endpoints')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+}

--- a/src/dispute/dispute.controller.spec.ts
+++ b/src/dispute/dispute.controller.spec.ts
@@ -1,0 +1,86 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { DisputeController } from './dispute.controller';
+import { DisputeService } from './dispute.service';
+import { DisputeTrigger } from './entities/dispute.entity';
+
+describe('DisputeController validation', () => {
+  let app: INestApplication;
+
+  const disputeService = {
+    createDispute: jest.fn().mockResolvedValue({ id: 'dispute-1' }),
+    startReview: jest.fn(),
+    resolveDispute: jest.fn(),
+    rejectDispute: jest.fn(),
+    getDisputeByClaimId: jest.fn(),
+    getExpiredDisputes: jest.fn(),
+    findAll: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DisputeController],
+      providers: [
+        {
+          provide: DisputeService,
+          useValue: disputeService,
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects unknown DTO fields with 400', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/disputes')
+      .send({
+        claimId: 'claim-1',
+        trigger: DisputeTrigger.MANUAL,
+        originalConfidence: 0.55,
+        unexpected: 'value',
+      })
+      .expect(400);
+
+    expect(response.body.message).toContain('property unexpected should not exist');
+    expect(disputeService.createDispute).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid dispute payloads with clear messages', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/disputes')
+      .send({
+        claimId: '',
+        trigger: 'INVALID_TRIGGER',
+        originalConfidence: 1.5,
+      })
+      .expect(400);
+
+    expect(response.body.message).toEqual(
+      expect.arrayContaining([
+        'claimId should not be empty',
+        'trigger must be one of the following values: LOW_CONFIDENCE, MINORITY_OPPOSITION, MANUAL',
+        'originalConfidence must not be greater than 1',
+      ]),
+    );
+    expect(disputeService.createDispute).not.toHaveBeenCalled();
+  });
+});

--- a/src/dispute/dispute.controller.ts
+++ b/src/dispute/dispute.controller.ts
@@ -9,29 +9,14 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { DisputeService } from './dispute.service';
+import { CreateDisputeDto } from './dto/create-dispute.dto';
+import { RejectDisputeDto } from './dto/reject-dispute.dto';
+import { ResolveDisputeDto } from './dto/resolve-dispute.dto';
 import {
   DisputeStatus,
   DisputeTrigger,
   DisputeOutcome,
 } from './entities/dispute.entity';
-
-class CreateDisputeDto {
-  claimId: string;
-  trigger: DisputeTrigger;
-  originalConfidence: number;
-  initiatorId?: string;
-  metadata?: Record<string, any>;
-}
-
-class ResolveDisputeDto {
-  outcome: DisputeOutcome;
-  finalConfidence: number;
-  metadata?: Record<string, any>;
-}
-
-class RejectDisputeDto {
-  reason: string;
-}
 
 @ApiTags('disputes')
 @Controller('disputes')

--- a/src/dispute/dto/create-dispute.dto.ts
+++ b/src/dispute/dto/create-dispute.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsNumber, IsObject, IsOptional, IsString, Max, Min } from 'class-validator';
+import { DisputeTrigger } from '../entities/dispute.entity';
+
+export class CreateDisputeDto {
+  @ApiProperty({ description: 'Claim identifier' })
+  @IsString()
+  @IsNotEmpty()
+  claimId: string;
+
+  @ApiProperty({ enum: DisputeTrigger, description: 'Reason the dispute was triggered' })
+  @IsEnum(DisputeTrigger)
+  trigger: DisputeTrigger;
+
+  @ApiProperty({ description: 'Confidence score before dispute resolution', minimum: 0, maximum: 1 })
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  originalConfidence: number;
+
+  @ApiPropertyOptional({ description: 'Optional user identifier for the dispute initiator' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  initiatorId?: string;
+
+  @ApiPropertyOptional({ description: 'Optional dispute metadata', type: 'object', additionalProperties: true })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/dispute/dto/reject-dispute.dto.ts
+++ b/src/dispute/dto/reject-dispute.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RejectDisputeDto {
+  @ApiProperty({ description: 'Reason the dispute was rejected' })
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}

--- a/src/dispute/dto/resolve-dispute.dto.ts
+++ b/src/dispute/dto/resolve-dispute.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsObject, IsOptional, Max, Min } from 'class-validator';
+import { DisputeOutcome } from '../entities/dispute.entity';
+
+export class ResolveDisputeDto {
+  @ApiProperty({ enum: DisputeOutcome, description: 'Final dispute outcome' })
+  @IsEnum(DisputeOutcome)
+  outcome: DisputeOutcome;
+
+  @ApiProperty({ description: 'Confidence score after dispute resolution', minimum: 0, maximum: 1 })
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  finalConfidence: number;
+
+  @ApiPropertyOptional({ description: 'Optional resolution metadata', type: 'object', additionalProperties: true })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/identity/worldcoin/worldcoin.service.spec.ts
+++ b/src/identity/worldcoin/worldcoin.service.spec.ts
@@ -4,14 +4,12 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { WorldcoinService } from './worldcoin.service';
 import { WorldIdVerification } from './entities/world-id-verification.entity';
-import { verifyCloudProof } from '@worldcoin/minikit-js';
-
-jest.mock('@worldcoin/minikit-js');
 
 describe('WorldcoinService', () => {
   let service: WorldcoinService;
   let repository: jest.Mocked<Repository<WorldIdVerification>>;
   let configService: jest.Mocked<ConfigService>;
+  let fetchMock: jest.Mock;
 
   const mockRepository = {
     findOne: jest.fn(),
@@ -41,18 +39,24 @@ describe('WorldcoinService', () => {
     service = module.get<WorldcoinService>(WorldcoinService);
     repository = module.get(getRepositoryToken(WorldIdVerification));
     configService = module.get(ConfigService);
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as typeof fetch;
 
     // Setup default config values
     configService.get.mockImplementation((key: string) => {
       const config = {
         'WORLDCOIN_APP_ID': 'test-app-id',
         'WORLDCOIN_ACTION': 'test-action',
+        'WORLDCOIN_VERIFY_BASE_URL': 'https://developer.worldcoin.org/api/v2/verify',
       };
       return config[key];
     });
 
-    // Mock verifyCloudProof to return success by default
-    (verifyCloudProof as jest.Mock).mockResolvedValue({ success: true });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ success: true }),
+    });
   });
 
   it('should be defined', () => {
@@ -93,11 +97,19 @@ describe('WorldcoinService', () => {
       const result = await service.verifyProof(userId, verifyDto);
 
       expect(result).toEqual(mockVerification);
-      expect(verifyCloudProof).toHaveBeenCalledWith(
-        verifyDto.proof,
-        'app_test-app-id',
-        verifyDto.action,
-        verifyDto.signal,
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://developer.worldcoin.org/api/v2/verify/test-app-id',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            ...verifyDto.proof,
+            action: verifyDto.action,
+            signal: verifyDto.signal,
+          }),
+        },
       );
       expect(repository.findOne).toHaveBeenCalledWith({
         where: { nullifierHash: verifyDto.proof.nullifier_hash },
@@ -131,14 +143,30 @@ describe('WorldcoinService', () => {
     });
 
     it('should throw BadRequestException for invalid proof', async () => {
-      // Mock verifyCloudProof to return failure
-      (verifyCloudProof as jest.Mock).mockResolvedValue({ success: false });
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ success: false }),
+      });
 
       repository.findOne.mockResolvedValue(null);
 
       await expect(service.verifyProof(userId, verifyDto)).rejects.toThrow(
         'Invalid Worldcoin proof',
       );
+    });
+
+    it('should throw BadRequestException when the action does not match config', async () => {
+      repository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.verifyProof(userId, {
+          ...verifyDto,
+          action: 'unexpected-action',
+        }),
+      ).rejects.toThrow('Invalid Worldcoin proof');
+
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/identity/worldcoin/worldcoin.service.ts
+++ b/src/identity/worldcoin/worldcoin.service.ts
@@ -4,12 +4,6 @@ import { Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { WorldIdVerification } from './entities/world-id-verification.entity';
 
-// Placeholder for worldcoin verification (package to be installed separately)
-const verifyCloudProof = async (proof: any, action: string, signal?: string): Promise<boolean> => {
-  // TODO: Replace with actual Worldcoin SDK when available
-  return false;
-};
-
 export interface VerifyWorldcoinProofDto {
   proof: {
     merkle_root: string;
@@ -19,6 +13,10 @@ export interface VerifyWorldcoinProofDto {
   };
   action: string;
   signal?: string;
+}
+
+interface WorldcoinCloudVerifyResponse {
+  success?: boolean;
 }
 
 @Injectable()
@@ -65,28 +63,47 @@ export class WorldcoinService {
   }
 
   private async verifyWorldcoinProof(
-    proof: any,
+    proof: VerifyWorldcoinProofDto['proof'],
     action: string,
     signal?: string,
   ): Promise<boolean> {
     try {
       const appId = this.configService.get<string>('WORLDCOIN_APP_ID');
       const expectedAction = this.configService.get<string>('WORLDCOIN_ACTION');
+      const verifyBaseUrl =
+        this.configService.get<string>('WORLDCOIN_VERIFY_BASE_URL') ??
+        'https://developer.worldcoin.org/api/v2/verify';
 
       if (!appId || !expectedAction) {
         this.logger.error('Worldcoin configuration missing');
         return false;
       }
 
-      // Placeholder: verify proof using Worldcoin SDK when available
-      // For now, just log and return true if basic validation passes
-      this.logger.debug(`Verifying Worldcoin proof for action: ${expectedAction}`);
-      
-      // TODO: Integrate actual @worldcoin/minikit-js SDK when available
-      // const result = await verifyCloudProof(proof, appId, action, signal);
-      // return result.success;
+      if (action !== expectedAction) {
+        this.logger.warn(`Worldcoin action mismatch: received ${action}, expected ${expectedAction}`);
+        return false;
+      }
 
-      return true;
+      const response = await fetch(`${verifyBaseUrl}/${appId}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...proof,
+          action,
+          ...(signal ? { signal } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        this.logger.warn(`Worldcoin verification request failed with status ${response.status}`);
+        return false;
+      }
+
+      const result = (await response.json()) as WorldcoinCloudVerifyResponse;
+
+      return result.success === true;
     } catch (error) {
       this.logger.error('Error verifying Worldcoin proof:', error);
       return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,73 +1,10 @@
 import { NestFactory } from '@nestjs/core';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
-import { ValidationPipe } from '@nestjs/common';
-import { Logger } from 'nestjs-pino';
+import { configureApp } from './bootstrap';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
-
-  // Use Pino logger for structured JSON logging
-  app.useLogger(app.get(Logger));
-
-  // Configure trust proxy for IP extraction
-  // Only trust specific proxy IPs from environment variable
-  const trustedProxies =
-    process.env.TRUSTED_PROXIES?.split(',')?.map((ip) => ip.trim()) || [];
-  if (trustedProxies.length > 0) {
-    app.set('trust proxy', trustedProxies);
-  } else {
-    // Default: trust no proxies (disable x-forwarded-for processing)
-    app.set('trust proxy', false);
-  }
-
-  // Enable strict validation
-  app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true, // Strip properties that don't have decorators
-      forbidNonWhitelisted: true, // Throw error if non-whitelisted properties are present
-      transform: true, // Automatically transform payloads to DTO instances
-      transformOptions: {
-        enableImplicitConversion: true, // Allow implicit type conversion
-      },
-    }),
-  );
-
-  // Swagger configuration
-  const config = new DocumentBuilder()
-    .setTitle('TruthBounty API')
-    .setDescription('## Decentralized News Verification Infrastructure\n\nThis API provides endpoints for managing claims, disputes, identity verification, rewards, and blockchain event indexing.\n\n### API Version\n- **Version**: 1.0\n- **Base Path**: `/`\n\n### Authentication\nMost mutating endpoints (POST, PATCH, PUT, DELETE) require authentication using wallet signature-based JWT tokens.\n\n#### Authentication Flow:\n1. Request a challenge: `POST /auth/challenge` with your wallet address\n2. Sign the challenge message with your wallet\n3. Login: `POST /auth/login` with address, signature, and message\n4. Use the returned JWT token in the `Authorization` header as `Bearer <token>`\n\nRead-only endpoints (GET) remain public unless specifically protected.\n\n### Rate Limiting\nSome endpoints are rate-limited using wallet-based throttling.')
-    .setVersion('1.0')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'JWT',
-        description: 'Enter JWT token',
-        in: 'header',
-      },
-      'JWT-auth',
-    )
-    .addTag('auth', 'Authentication with wallet signature')
-    .addTag('identity', 'User and wallet identity management')
-    .addTag('worldcoin', 'Worldcoin ID verification')
-    .addTag('claims', 'Claim management and evidence')
-    .addTag('evidence', 'Evidence management with flagging')
-    .addTag('disputes', 'Dispute creation and resolution')
-    .addTag('sybil', 'Sybil resistance scoring')
-    .addTag('blockchain', 'Blockchain event indexing and state')
-    .addTag('indexer', 'Event indexer management')
-    .addTag('rewards', 'Reward management')
-    .addTag('leaderboard', 'User leaderboard rankings')
-    .addTag('audit', 'Audit log retrieval')
-    .addTag('health', 'Health check endpoints')
-    .build();
-
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
-
-  app.useGlobalPipes(new ValidationPipe());
+  configureApp(app);
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
This PR fixes three API issues in the TruthBounty backend.

Summary:
- extract dispute request DTOs into src/dispute/dto and add strict class-validator decorators
- remove the duplicate global ValidationPipe registration and cover strict pipe setup with a regression test
- replace the Worldcoin always-true verification stub with a real cloud verification request and reject invalid proofs with 400

Tests:
- npm test -- --runInBand --runTestsByPath src/dispute/dispute.controller.spec.ts src/identity/worldcoin/worldcoin.service.spec.ts src/bootstrap.spec.ts

Notes:
- the unrelated local package-lock.json change was intentionally left out of this PR
- full project build still has pre-existing unrelated TypeScript errors outside this change set

Closes #80
Closes #94
Closes #104