### PR TITLE
fix: validate linked wallet addresses

### DIFF
--- a/src/identity/dto/link-wallet.dto.spec.ts
+++ b/src/identity/dto/link-wallet.dto.spec.ts
@@ -1,0 +1,36 @@
+import { validate } from 'class-validator';
+import { LinkWalletDto } from './link-wallet.dto';
+
+function createDto(address: string): LinkWalletDto {
+  const dto = new LinkWalletDto();
+  dto.address = address;
+  dto.chain = 'ethereum';
+  dto.signature = '0xsignature';
+  dto.message = 'Link this wallet';
+  return dto;
+}
+
+describe('LinkWalletDto', () => {
+  it('accepts valid Ethereum addresses', async () => {
+    const errors = await validate(
+      createDto('0x52908400098527886E0F7030069857D2E4169EE7'),
+    );
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each([
+    '52908400098527886E0F7030069857D2E4169EE7',
+    '0x52908400098527886E0F7030069857D2E4169EE',
+    '0x52908400098527886E0F7030069857D2E4169EE71',
+    '0x52908400098527886E0F7030069857D2E4169EGG',
+  ])('rejects invalid Ethereum address %s', async (address) => {
+    const errors = await validate(createDto(address));
+    const addressError = errors.find((error) => error.property === 'address');
+
+    expect(addressError?.constraints).toHaveProperty(
+      'isEthereumAddress',
+      'address must be a valid Ethereum address',
+    );
+  });
+});

--- a/src/identity/dto/link-wallet.dto.ts
+++ b/src/identity/dto/link-wallet.dto.ts
@@ -1,6 +1,7 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsEthereumAddress, IsNotEmpty, IsString } from 'class-validator';
 
 export class LinkWalletDto {
+  @IsEthereumAddress({ message: 'address must be a valid Ethereum address' })
   @IsString()
   @IsNotEmpty()
   address: string;


### PR DESCRIPTION
## Summary
- Adds `@IsEthereumAddress()` validation to `LinkWalletDto.address` with a clear validation message.
- Adds focused DTO tests for valid and invalid Ethereum address formats.

## Validation
- `npm test -- link-wallet.dto.spec.ts --runInBand`
- `npx prettier --check src/identity/dto/link-wallet.dto.ts src/identity/dto/link-wallet.dto.spec.ts`

## Existing local build blockers observed
- `npm ci` currently fails because `package.json` and `package-lock.json` are out of sync (`prom-client@15.1.3` is missing from the lockfile).
- After installing without modifying the lockfile, `npm run build` fails on existing unrelated TypeScript errors in `src/blockchain/reorg-detector.service.ts`, `src/main.ts`, `src/modules/sybil/*`, and `src/storage/cid-verifier.ts`.

Closes #110
