### PR TITLE
Remove N+1 queries in sybil-weighted voting (batch score fetch)

### DIFF
--- a/src/audit/services/audit-trail.service.ts
+++ b/src/audit/services/audit-trail.service.ts
@@ -162,19 +162,19 @@ export class AuditTrailService {
     limit = 100,
     offset = 0,
   ): Promise<{ logs: AuditLog[]; total: number }> {
-    const [logs, total] = await this.auditLogRepo.findAndCount({
-      order: { createdAt: 'DESC' },
-      skip: offset,
-      take: limit,
-      relations: ['user'],
-    });
+    const [logs, total] = await this.auditLogRepo
+      .createQueryBuilder('audit')
+      .leftJoinAndSelect('audit.user', 'user')
+      .where('audit.createdAt BETWEEN :startDate AND :endDate', {
+        startDate,
+        endDate,
+      })
+      .orderBy('audit.createdAt', 'DESC')
+      .skip(offset)
+      .take(limit)
+      .getManyAndCount();
 
-    // Manual filtering for date range (TypeORM SQLite limitation)
-    const filteredLogs = logs.filter(
-      (log) => log.createdAt >= startDate && log.createdAt <= endDate,
-    );
-
-    return { logs: filteredLogs, total: filteredLogs.length };
+    return { logs, total };
   }
 
   /**

--- a/src/sybil-resistance/sybil-resistance.service.ts
+++ b/src/sybil-resistance/sybil-resistance.service.ts
@@ -241,6 +241,43 @@ Final score: ${Number(composite.toFixed(4))} (weighted average)`,
   }
 
   /**
+   * Get the most recent Sybil scores for multiple users in a single query
+   */
+  async getLatestSybilScores(userIds: string[]): Promise<Map<string, any>> {
+    if (userIds.length === 0) {
+      return new Map();
+    }
+
+    const uniqueUserIds = [...new Set(userIds)];
+
+    // Batch fetch all scores ordered by newest first
+    const scores = await this.prisma.sybilScore.findMany({
+      where: { userId: { in: uniqueUserIds } },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const latestByUser = new Map<string, any>();
+    for (const score of scores) {
+      if (!latestByUser.has(score.userId)) {
+        latestByUser.set(score.userId, score);
+      }
+    }
+
+    // Compute missing scores in parallel
+    const missingUserIds = uniqueUserIds.filter((id) => !latestByUser.has(id));
+    if (missingUserIds.length > 0) {
+      const computedScores = await Promise.all(
+        missingUserIds.map((userId) => this.recordSybilScore(userId)),
+      );
+      for (let i = 0; i < missingUserIds.length; i++) {
+        latestByUser.set(missingUserIds[i], computedScores[i]);
+      }
+    }
+
+    return latestByUser;
+  }
+
+  /**
    * Get all Sybil score history for a user
    */
   async getSybilScoreHistory(userId: string, limit: number = 10): Promise<any[]> {

--- a/src/sybil-resistance/sybil-resistant-voting.service.spec.ts
+++ b/src/sybil-resistance/sybil-resistant-voting.service.spec.ts
@@ -18,6 +18,7 @@ describe('SybilResistantVotingService', () => {
           provide: SybilResistanceService,
           useValue: {
             getLatestSybilScore: jest.fn(),
+            getLatestSybilScores: jest.fn(),
           },
         },
       ],
@@ -107,35 +108,15 @@ describe('SybilResistantVotingService', () => {
 
   describe('calculateSybilWeightedVotes', () => {
     it('should calculate weights for multiple votes', async () => {
-      const mockScores = [
-        {
-          compositeScore: 0.8,
-          worldcoinScore: 1.0,
-          walletAgeScore: 0.8,
-          stakingScore: 0.6,
-          accuracyScore: 0.8,
-        },
-        {
-          compositeScore: 0.5,
-          worldcoinScore: 0.0,
-          walletAgeScore: 0.67,
-          stakingScore: 0.0,
-          accuracyScore: 0.0,
-        },
-        {
-          compositeScore: 1.0,
-          worldcoinScore: 1.0,
-          walletAgeScore: 1.0,
-          stakingScore: 1.0,
-          accuracyScore: 1.0,
-        },
-      ];
+      const scoreMap = new Map([
+        [mockUser1, { compositeScore: 0.8 }],
+        [mockUser2, { compositeScore: 0.5 }],
+        [mockUser3, { compositeScore: 1.0 }],
+      ]);
 
       jest
-        .spyOn(sybilService, 'getLatestSybilScore')
-        .mockResolvedValueOnce(mockScores[0] as any)
-        .mockResolvedValueOnce(mockScores[1] as any)
-        .mockResolvedValueOnce(mockScores[2] as any);
+        .spyOn(sybilService, 'getLatestSybilScores')
+        .mockResolvedValue(scoreMap as any);
 
       const votes = [
         { userId: mockUser1, baseWeight: 100 },
@@ -149,32 +130,24 @@ describe('SybilResistantVotingService', () => {
       expect(results[0].finalWeight).toBe(90); // 0.9 multiplier
       expect(results[1].finalWeight).toBe(75); // 0.75 multiplier
       expect(results[2].finalWeight).toBe(100); // 1.0 multiplier
+      expect(sybilService.getLatestSybilScores).toHaveBeenCalledWith([
+        mockUser1,
+        mockUser2,
+        mockUser3,
+      ]);
     });
   });
 
   describe('getVotingImpactAnalysis', () => {
     it('should show weight reduction impact', async () => {
-      const mockScores = [
-        {
-          compositeScore: 0.8,
-          worldcoinScore: 1.0,
-          walletAgeScore: 0.8,
-          stakingScore: 0.6,
-          accuracyScore: 0.8,
-        },
-        {
-          compositeScore: 0.0,
-          worldcoinScore: 0.0,
-          walletAgeScore: 0.0,
-          stakingScore: 0.0,
-          accuracyScore: 0.0,
-        },
-      ];
+      const scoreMap = new Map([
+        [mockUser1, { compositeScore: 0.8 }],
+        [mockUser2, { compositeScore: 0.0 }],
+      ]);
 
       jest
-        .spyOn(sybilService, 'getLatestSybilScore')
-        .mockResolvedValueOnce(mockScores[0] as any)
-        .mockResolvedValueOnce(mockScores[1] as any);
+        .spyOn(sybilService, 'getLatestSybilScores')
+        .mockResolvedValue(scoreMap as any);
 
       const votes = [
         { userId: mockUser1, verdict: 'TRUE', baseWeight: 100 },
@@ -187,6 +160,10 @@ describe('SybilResistantVotingService', () => {
       expect(result.sybilAdjustedTotalWeight).toBe(140); // 90 + 50
       expect(result.weightReduction).toBe(60);
       expect(result.percentageChange).toBe('30.00%');
+      expect(sybilService.getLatestSybilScores).toHaveBeenCalledWith([
+        mockUser1,
+        mockUser2,
+      ]);
     });
   });
 
@@ -237,38 +214,15 @@ describe('SybilResistantVotingService', () => {
 
   describe('getParticipationEligibility', () => {
     it('should report eligibility statistics', async () => {
-      const mockScores = [
-        {
-          id: 'score-1',
-          compositeScore: 0.7,
-          worldcoinScore: 1.0,
-          walletAgeScore: 0.7,
-          stakingScore: 0.4,
-          accuracyScore: 0.6,
-        },
-        {
-          id: 'score-2',
-          compositeScore: 0.3,
-          worldcoinScore: 0.0,
-          walletAgeScore: 0.4,
-          stakingScore: 0.0,
-          accuracyScore: 0.0,
-        },
-        {
-          id: 'score-3',
-          compositeScore: 0.9,
-          worldcoinScore: 1.0,
-          walletAgeScore: 0.9,
-          stakingScore: 0.8,
-          accuracyScore: 0.9,
-        },
-      ];
+      const scoreMap = new Map([
+        [mockUser1, { compositeScore: 0.7 }],
+        [mockUser2, { compositeScore: 0.3 }],
+        [mockUser3, { compositeScore: 0.9 }],
+      ]);
 
       jest
-        .spyOn(sybilService, 'getLatestSybilScore')
-        .mockResolvedValueOnce(mockScores[0] as any)
-        .mockResolvedValueOnce(mockScores[1] as any)
-        .mockResolvedValueOnce(mockScores[2] as any);
+        .spyOn(sybilService, 'getLatestSybilScores')
+        .mockResolvedValue(scoreMap as any);
 
       const result = await votingService.getParticipationEligibility(
         [mockUser1, mockUser2, mockUser3],
@@ -279,15 +233,25 @@ describe('SybilResistantVotingService', () => {
       expect(result.eligibleUsers).toBe(2); // Users 1 and 3
       expect(result.ineligibleUsers).toBe(1); // User 2
       expect(result.eligibilityRate).toBe('66.67%');
+      expect(sybilService.getLatestSybilScores).toHaveBeenCalledWith([
+        mockUser1,
+        mockUser2,
+        mockUser3,
+      ]);
     });
 
     it('should handle empty user list', async () => {
+      jest
+        .spyOn(sybilService, 'getLatestSybilScores')
+        .mockResolvedValue(new Map() as any);
+
       const result = await votingService.getParticipationEligibility([], 0.5);
 
       expect(result.totalUsers).toBe(0);
       expect(result.eligibleUsers).toBe(0);
       expect(result.ineligibleUsers).toBe(0);
       expect(result.eligibilityRate).toBe('0%');
+      expect(sybilService.getLatestSybilScores).toHaveBeenCalledWith([]);
     });
   });
 

--- a/src/sybil-resistance/sybil-resistant-voting.service.ts
+++ b/src/sybil-resistance/sybil-resistant-voting.service.ts
@@ -69,29 +69,23 @@ export class SybilResistantVotingService {
     multiplier: number;
     finalWeight: number;
   }>> {
-    const results: Array<{
-      userId: string;
-      baseWeight: number;
-      sybilScore: number;
-      multiplier: number;
-      finalWeight: number;
-    }> = [];
+    const userIds = [...new Set(votes.map((v) => v.userId))];
+    const scores = await this.sybilService.getLatestSybilScores(userIds);
 
-    for (const vote of votes) {
-      const weighted = await this.calculateSybilWeightedVote(
-        vote.userId,
-        vote.baseWeight,
-      );
-      results.push({
-        userId: weighted.userId,
-        baseWeight: weighted.baseWeight,
-        sybilScore: weighted.sybilScore,
-        multiplier: weighted.multiplier,
-        finalWeight: weighted.finalWeight,
-      });
-    }
+    return votes.map((vote) => {
+      const sybilScore = scores.get(vote.userId);
+      const compositeScore = sybilScore?.compositeScore ?? 0;
+      const multiplier = 0.5 + 0.5 * compositeScore;
+      const finalWeight = vote.baseWeight * multiplier;
 
-    return results;
+      return {
+        userId: vote.userId,
+        baseWeight: vote.baseWeight,
+        sybilScore: compositeScore,
+        multiplier,
+        finalWeight,
+      };
+    });
   }
 
   /**
@@ -113,6 +107,9 @@ export class SybilResistantVotingService {
       adjustedWeight: number;
     }>;
   }> {
+    const userIds = [...new Set(votes.map((v) => v.userId))];
+    const scores = await this.sybilService.getLatestSybilScores(userIds);
+
     let originalTotalWeight = 0;
     let sybilAdjustedTotalWeight = 0;
     const details: Array<{
@@ -126,19 +123,19 @@ export class SybilResistantVotingService {
     for (const vote of votes) {
       originalTotalWeight += vote.baseWeight;
 
-      const weighted = await this.calculateSybilWeightedVote(
-        vote.userId,
-        vote.baseWeight,
-      );
+      const sybilScore = scores.get(vote.userId);
+      const compositeScore = sybilScore?.compositeScore ?? 0;
+      const multiplier = 0.5 + 0.5 * compositeScore;
+      const adjustedWeight = vote.baseWeight * multiplier;
 
-      sybilAdjustedTotalWeight += weighted.finalWeight;
+      sybilAdjustedTotalWeight += adjustedWeight;
 
       details.push({
         userId: vote.userId,
         verdict: vote.verdict,
         baseWeight: vote.baseWeight,
-        sybilScore: weighted.sybilScore,
-        adjustedWeight: weighted.finalWeight,
+        sybilScore: compositeScore,
+        adjustedWeight,
       });
     }
 
@@ -195,6 +192,8 @@ export class SybilResistantVotingService {
       eligible: boolean;
     }>;
   }> {
+    const scores = await this.sybilService.getLatestSybilScores(userIds);
+
     const details: Array<{
       userId: string;
       currentScore: number;
@@ -203,14 +202,17 @@ export class SybilResistantVotingService {
     let eligibleCount = 0;
 
     for (const userId of userIds) {
-      const result = await this.meetsMinimumSybilScore(userId, minimumScore);
+      const sybilScore = scores.get(userId);
+      const currentScore = sybilScore?.compositeScore ?? 0;
+      const eligible = currentScore >= minimumScore;
+
       details.push({
-        userId: result.userId,
-        currentScore: result.currentScore,
-        eligible: result.eligible,
+        userId,
+        currentScore,
+        eligible,
       });
 
-      if (result.eligible) {
+      if (eligible) {
         eligibleCount++;
       }
     }


### PR DESCRIPTION
Result
For 100 votes from users with existing scores: 1 DB query (O(1)) instead of 100 sequential queries (O(N)).
The singular calculateSybilWeightedVote and meetsMinimumSybilScore methods remain unchanged for single-use callers.

Closes #88 

Closes #99 