### PR TITLE
feat(blockchain): implement in-memory state service with configurable memory limits and eviction logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,11 @@ CACHE_CLAIMS_TTL=3600  # Claim cache TTL in seconds
 # ==============================================
 # Blockchain Configuration
 # ==============================================
+# In-memory state service memory limits (prevents OOM)
+# Controls how many blocks, events, and reorg entries are kept in memory
+BLOCKCHAIN_MAX_BLOCKS=10000        # Max block records in memory (default: 10000)
+BLOCKCHAIN_MAX_EVENTS=50000        # Max pending/confirmed/orphaned events (default: 50000)
+BLOCKCHAIN_MAX_REORG_HISTORY=1000  # Max reorg history entries (default: 1000)
 # Redis configuration
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/package-lock.json
+++ b/package-lock.json
@@ -3715,7 +3715,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
       "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3757,7 +3757,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3774,7 +3773,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3791,7 +3789,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3808,7 +3805,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3825,7 +3821,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3842,7 +3837,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3859,7 +3853,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3876,7 +3869,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3893,7 +3885,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3910,7 +3901,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3924,14 +3914,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/src/blockchain/state.service.spec.ts
+++ b/src/blockchain/state.service.spec.ts
@@ -1,0 +1,454 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { BlockchainStateService } from './state.service';
+import { BlockInfo, PendingEvent, ReorgEvent } from './types';
+
+describe('BlockchainStateService', () => {
+  let service: BlockchainStateService;
+
+  const makeBlock = (num: number, hash?: string): BlockInfo => ({
+    number: num,
+    hash: hash ?? `0x${num.toString(16).padStart(64, '0')}`,
+    parentHash: hash
+      ? `0x${(num - 1).toString(16).padStart(64, '0')}`
+      : '0x0000000000000000000000000000000000000000000000000000000000000000',
+    timestamp: Math.floor(Date.now() / 1000) + num,
+  });
+
+  const makePendingEvent = (
+    id: string,
+    blockNumber: number,
+    status: 'pending' | 'confirmed' | 'orphaned' = 'pending',
+  ): PendingEvent => ({
+    id,
+    blockNumber,
+    blockHash: `0x${blockNumber.toString(16).padStart(64, '0')}`,
+    eventType: 'TestEvent',
+    data: {},
+    transactionHash: `0x${id}`,
+    logIndex: 0,
+    status,
+    confirmations: status === 'confirmed' ? 100 : 0,
+    createdAt: new Date(),
+    confirmedAt: status === 'confirmed' ? new Date() : undefined,
+  });
+
+  describe('with default config (no ConfigService)', () => {
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [BlockchainStateService],
+      }).compile();
+
+      service = module.get<BlockchainStateService>(BlockchainStateService);
+    });
+
+    afterEach(async () => {
+      await service.clearAllState();
+    });
+
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+    it('should apply default memory limits', async () => {
+      const stats = await service.getMemoryStats();
+      expect(stats.maxBlocksInMemory).toBe(10000);
+      expect(stats.maxEventsInMemory).toBe(50000);
+      expect(stats.maxReorgHistoryEntries).toBe(1000);
+    });
+
+    it('should track block count in memory stats', async () => {
+      await service.saveBlock(makeBlock(1));
+      await service.saveBlock(makeBlock(2));
+      await service.saveBlock(makeBlock(3));
+
+      const stats = await service.getMemoryStats();
+      expect(stats.currentBlockCount).toBe(3);
+    });
+
+    it('should track event counts by status in memory stats', async () => {
+      const e1 = makePendingEvent('evt1', 1, 'pending');
+      const e2 = makePendingEvent('evt2', 2, 'confirmed');
+      const e3 = makePendingEvent('evt3', 3, 'orphaned');
+
+      await service.savePendingEvent(e1);
+      await service.savePendingEvent(e2);
+      await service.savePendingEvent(e3);
+
+      const stats = await service.getMemoryStats();
+      expect(stats.currentEventCount).toBe(3);
+      expect(stats.pendingEventCount).toBe(1);
+      expect(stats.confirmedEventCount).toBe(1);
+      expect(stats.orphanedEventCount).toBe(1);
+    });
+
+    it('should track reorg history count in memory stats', async () => {
+      await service.recordReorg({
+        detectedAt: new Date(),
+        reorgDepth: 1,
+        affectedBlockStart: 10,
+        affectedBlockEnd: 10,
+        orphanedEvents: [],
+        reprocessedEvents: [],
+      });
+
+      const stats = await service.getMemoryStats();
+      expect(stats.currentReorgHistoryCount).toBe(1);
+    });
+  });
+
+  describe('with custom memory limits via ConfigService', () => {
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          BlockchainStateService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn((key: string, defaultValue: number) => {
+                const config: Record<string, number> = {
+                  'blockchain.maxBlocksInMemory': 3,
+                  'blockchain.maxEventsInMemory': 5,
+                  'blockchain.maxReorgHistoryEntries': 2,
+                };
+                return config[key] ?? defaultValue;
+              }),
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get<BlockchainStateService>(BlockchainStateService);
+    });
+
+    afterEach(async () => {
+      await service.clearAllState();
+    });
+
+    describe('block eviction', () => {
+      it('should evict oldest blocks when limit is exceeded', async () => {
+        for (let i = 1; i <= 5; i++) {
+          await service.saveBlock(makeBlock(i));
+        }
+
+        const stats = await service.getMemoryStats();
+        expect(stats.currentBlockCount).toBe(3);
+      });
+
+      it('should keep the most recent blocks after eviction', async () => {
+        for (let i = 80; i <= 200; i++) {
+          await service.saveBlock(makeBlock(i));
+        }
+
+        // With maxBlocksInMemory=3, only the 3 newest blocks survive
+        const stats = await service.getMemoryStats();
+        expect(stats.currentBlockCount).toBe(3);
+
+        // Block 190 should not exist (only blocks 198, 199, 200 remain)
+        const evictedBlock = await service.getBlock(190, makeBlock(190).hash);
+        expect(evictedBlock).toBeNull();
+      });
+
+      it('should evict blocks starting from the oldest', async () => {
+        for (let i = 1; i <= 5; i++) {
+          await service.saveBlock(makeBlock(i));
+        }
+
+        // Oldest blocks (1, 2) should be evicted, newest ones (3, 4, 5) remain
+        const oldestBlock = await service.getBlock(1, makeBlock(1).hash);
+        expect(oldestBlock).toBeNull();
+
+        const newestBlock = await service.getBlock(5, makeBlock(5).hash);
+        expect(newestBlock).not.toBeNull();
+      });
+
+      it('should keep all blocks when under the limit', async () => {
+        for (let i = 1; i <= 3; i++) {
+          await service.saveBlock(makeBlock(i));
+        }
+
+        const stats = await service.getMemoryStats();
+        expect(stats.currentBlockCount).toBe(3);
+      });
+    });
+
+    describe('event eviction', () => {
+      it('should evict oldest confirmed events when limit is exceeded', async () => {
+        for (let i = 1; i <= 10; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`evt-${i}`, i, 'confirmed'),
+          );
+        }
+
+        const stats = await service.getMemoryStats();
+        expect(stats.currentEventCount).toBeLessThanOrEqual(5);
+      });
+
+      it('should never evict pending events', async () => {
+        // Add 5 pending events (filling the limit)
+        for (let i = 1; i <= 5; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`pending-${i}`, i, 'pending'),
+          );
+        }
+
+        // Add 5 more confirmed events (exceeds limit)
+        for (let i = 6; i <= 10; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`confirmed-${i}`, i, 'confirmed'),
+          );
+        }
+
+        // Pending events should all still be present
+        for (let i = 1; i <= 5; i++) {
+          const evt = await service.getEvent(`pending-${i}`);
+          expect(evt).not.toBeNull();
+          expect(evt!.status).toBe('pending');
+        }
+
+        const stats = await service.getMemoryStats();
+        expect(stats.pendingEventCount).toBe(5);
+      });
+
+      it('should never evict orphaned events', async () => {
+        // Add 5 orphaned events
+        for (let i = 1; i <= 5; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`orphan-${i}`, i, 'orphaned'),
+          );
+        }
+
+        // Add 5 confirmed events (exceeds limit)
+        for (let i = 6; i <= 10; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`confirmed-${i}`, i, 'confirmed'),
+          );
+        }
+
+        // Orphaned events should all still be present
+        for (let i = 1; i <= 5; i++) {
+          const evt = await service.getEvent(`orphan-${i}`);
+          expect(evt).not.toBeNull();
+          expect(evt!.status).toBe('orphaned');
+        }
+
+        const stats = await service.getMemoryStats();
+        expect(stats.orphanedEventCount).toBe(5);
+      });
+
+      it('should evict confirmed events oldest-first', async () => {
+        const fillerDate = new Date('2020-01-01');
+        for (let i = 1; i <= 10; i++) {
+          const filler = makePendingEvent(`filler-${i}`, i, 'confirmed');
+          filler.confirmedAt = fillerDate;
+          await service.savePendingEvent(filler);
+        }
+
+        const recentEvent: PendingEvent = {
+          ...makePendingEvent('recent-event', 100, 'confirmed'),
+          confirmedAt: new Date('2024-01-01'),
+        };
+        await service.savePendingEvent(recentEvent);
+
+        // With maxEventsInMemory=5 and 11 events saved (10 fillers + 1 recent),
+        // the 6 oldest fillers should be evicted; remaining 4 fillers + 1 recent = within limit
+        for (let i = 1; i <= 6; i++) {
+          const evicted = await service.getEvent(`filler-${i}`);
+          expect(evicted).toBeNull();
+        }
+
+        const kept = await service.getEvent('recent-event');
+        expect(kept).not.toBeNull();
+      });
+    });
+
+    describe('reorg history trimming', () => {
+      it('should trim oldest reorg entries when limit exceeded', async () => {
+        for (let i = 1; i <= 5; i++) {
+          await service.recordReorg({
+            detectedAt: new Date(2020, 0, i),
+            reorgDepth: 1,
+            affectedBlockStart: i * 10,
+            affectedBlockEnd: i * 10,
+            orphanedEvents: [],
+            reprocessedEvents: [],
+          });
+        }
+
+        const history = await service.getReorgHistory();
+        expect(history.length).toBeLessThanOrEqual(2);
+      });
+
+      it('should keep the most recent reorg entries', async () => {
+        for (let i = 1; i <= 5; i++) {
+          await service.recordReorg({
+            detectedAt: new Date(2024, 0, i),
+            reorgDepth: i,
+            affectedBlockStart: i * 10,
+            affectedBlockEnd: i * 10,
+            orphanedEvents: [`event-${i}`],
+            reprocessedEvents: [],
+          });
+        }
+
+        const history = await service.getReorgHistory();
+        // Should keep the last 2 entries
+        expect(history.length).toBe(2);
+        expect(history[0].reorgDepth).toBe(4);
+        expect(history[1].reorgDepth).toBe(5);
+      });
+    });
+
+    describe('correctness under normal load', () => {
+      it('should not evict blocks when under the limit', async () => {
+        await service.updateChainState({ lastProcessedBlock: 10, confirmedDepth: 12 });
+
+        for (let i = 1; i <= 3; i++) {
+          await service.saveBlock(makeBlock(i));
+        }
+
+        const stats = await service.getMemoryStats();
+        expect(stats.currentBlockCount).toBe(3);
+      });
+
+      it('should not evict events when under the limit', async () => {
+        for (let i = 1; i <= 5; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`evt-${i}`, i, 'confirmed'),
+          );
+        }
+
+        const stats = await service.getMemoryStats();
+        expect(stats.currentEventCount).toBe(5);
+      });
+
+      it('should preserve canonical queries after eviction', async () => {
+        await service.updateChainState({ lastProcessedBlock: 50, confirmedDepth: 12 });
+
+        for (let i = 45; i <= 50; i++) {
+          await service.saveBlock(makeBlock(i));
+        }
+
+        // Canonical block at height 49 should still exist
+        const canonical = await service.getCanonicalBlock(49);
+        expect(canonical).not.toBeNull();
+        expect(canonical!.blockNumber).toBe(49);
+        expect(canonical!.isCanonical).toBe(true);
+      });
+
+      it('should preserve event retrieval after eviction', async () => {
+        for (let i = 1; i <= 5; i++) {
+          const evt = makePendingEvent(`evt-${i}`, i, 'confirmed');
+          await service.savePendingEvent(evt);
+        }
+
+        // All events should still be retrievable
+        for (let i = 1; i <= 5; i++) {
+          const evt = await service.getEvent(`evt-${i}`);
+          expect(evt).not.toBeNull();
+          expect(evt!.id).toBe(`evt-${i}`);
+        }
+      });
+
+      it('should maintain pending event count accuracy after eviction', async () => {
+        for (let i = 1; i <= 5; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`pending-${i}`, i, 'pending'),
+          );
+        }
+
+        // Add confirmed events to trigger eviction
+        for (let i = 6; i <= 15; i++) {
+          await service.savePendingEvent(
+            makePendingEvent(`confirmed-${i}`, i, 'confirmed'),
+          );
+        }
+
+        // When confirmed events are evicted, pendingEventCount should remain accurate
+        const chainState = await service.getChainState();
+        const pendingEvents = await service.getPendingEvents();
+        expect(pendingEvents.length).toBe(chainState.pendingEventCount);
+      });
+    });
+  });
+
+  describe('protocol invariants', () => {
+    it('should never have negative pending event count', async () => {
+      const chainState = await service.getChainState();
+      expect(chainState.pendingEventCount).toBeGreaterThanOrEqual(0);
+      expect(chainState.orphanedEventCount).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should have consistent pending event count after state transitions', async () => {
+      const evt = makePendingEvent('transition-test', 1, 'pending');
+      await service.savePendingEvent(evt);
+
+      let state = await service.getChainState();
+      expect(state.pendingEventCount).toBe(1);
+
+      await service.updateEventStatus('transition-test', 'confirmed');
+      state = await service.getChainState();
+      expect(state.pendingEventCount).toBe(0);
+
+      await service.updateEventStatus('transition-test', 'orphaned');
+      state = await service.getChainState();
+      expect(state.orphanedEventCount).toBe(1);
+    });
+
+    it('should have total event count match sum of status counts', async () => {
+      await service.savePendingEvent(makePendingEvent('a', 1, 'pending'));
+      await service.savePendingEvent(makePendingEvent('b', 2, 'confirmed'));
+      await service.savePendingEvent(makePendingEvent('c', 3, 'orphaned'));
+
+      const stats = await service.getMemoryStats();
+      const sum =
+        stats.pendingEventCount +
+        stats.confirmedEventCount +
+        stats.orphanedEventCount;
+      expect(stats.currentEventCount).toBe(sum);
+    });
+
+    it('should keep only the most recent blocks when limit is exceeded', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          BlockchainStateService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn((key: string, defaultValue: number) => {
+                const config: Record<string, number> = {
+                  'blockchain.maxBlocksInMemory': 5,
+                  'blockchain.maxEventsInMemory': 50,
+                  'blockchain.maxReorgHistoryEntries': 10,
+                };
+                return config[key] ?? defaultValue;
+              }),
+            },
+          },
+        ],
+      }).compile();
+
+      const svc = module.get<BlockchainStateService>(BlockchainStateService);
+
+      for (let i = 1; i <= 20; i++) {
+        await svc.saveBlock(makeBlock(i));
+      }
+
+      // Only the 5 newest blocks (16-20) should remain
+      const stats = await svc.getMemoryStats();
+      expect(stats.currentBlockCount).toBe(5);
+
+      for (let i = 1; i <= 15; i++) {
+        const b = await svc.getBlock(i, makeBlock(i).hash);
+        expect(b).toBeNull();
+      }
+
+      for (let i = 16; i <= 20; i++) {
+        const b = await svc.getBlock(i, makeBlock(i).hash);
+        expect(b).not.toBeNull();
+      }
+
+      await svc.clearAllState();
+    });
+  });
+});

--- a/src/blockchain/state.service.ts
+++ b/src/blockchain/state.service.ts
@@ -1,19 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   BlockRecord,
   PendingEvent,
   ReorgEvent,
   ChainState,
   BlockInfo,
+  StateMemoryStats,
 } from './types';
 
-/**
- * In-memory state management for blockchain tracking
- * In production, this would be backed by a persistent database (PostgreSQL, MongoDB, etc.)
- */
 @Injectable()
 export class BlockchainStateService {
-  // In-memory storage (replace with database in production)
+  private readonly logger = new Logger(BlockchainStateService.name);
+
   private blocks: Map<string, BlockRecord> = new Map();
   private events: Map<string, PendingEvent> = new Map();
   private reorgHistory: ReorgEvent[] = [];
@@ -25,9 +24,30 @@ export class BlockchainStateService {
     orphanedEventCount: 0,
   };
 
-  /**
-   * Store a block record
-   */
+  private readonly maxBlocksInMemory: number;
+  private readonly maxEventsInMemory: number;
+  private readonly maxReorgHistoryEntries: number;
+
+  constructor(
+    @Optional() private configService?: ConfigService,
+  ) {
+    this.maxBlocksInMemory = this.configService?.get<number>(
+      'blockchain.maxBlocksInMemory', 10000,
+    ) ?? 10000;
+    this.maxEventsInMemory = this.configService?.get<number>(
+      'blockchain.maxEventsInMemory', 50000,
+    ) ?? 50000;
+    this.maxReorgHistoryEntries = this.configService?.get<number>(
+      'blockchain.maxReorgHistoryEntries', 1000,
+    ) ?? 1000;
+
+    this.logger.log(
+      `Memory limits — blocks: ${this.maxBlocksInMemory}, ` +
+      `events: ${this.maxEventsInMemory}, ` +
+      `reorg history: ${this.maxReorgHistoryEntries}`,
+    );
+  }
+
   async saveBlock(block: BlockInfo): Promise<BlockRecord> {
     const blockRecord: BlockRecord = {
       id: `${block.number}:${block.hash}`,
@@ -40,43 +60,31 @@ export class BlockchainStateService {
     };
 
     this.blocks.set(blockRecord.id, blockRecord);
+    this.evictOldBlocks();
     return blockRecord;
   }
 
-  /**
-   * Get block by number and hash
-   */
   async getBlock(blockNumber: number, blockHash: string): Promise<BlockRecord | null> {
     const record = this.blocks.get(`${blockNumber}:${blockHash}`);
     return record || null;
   }
 
-  /**
-   * Get all blocks at a specific block number
-   */
   async getBlocksAtHeight(blockNumber: number): Promise<BlockRecord[]> {
-    const blocks: BlockRecord[] = [];
+    const result: BlockRecord[] = [];
     this.blocks.forEach((block) => {
       if (block.blockNumber === blockNumber) {
-        blocks.push(block);
+        result.push(block);
       }
     });
-    return blocks;
+    return result;
   }
 
-  /**
-   * Get the canonical block at a height
-   */
   async getCanonicalBlock(blockNumber: number): Promise<BlockRecord | null> {
     const blocks = await this.getBlocksAtHeight(blockNumber);
     return blocks.find((b) => b.isCanonical) || null;
   }
 
-  /**
-   * Get the canonical block by its hash
-   */
   async getCanonicalBlockByHash(blockHash: string): Promise<BlockRecord | null> {
-    // Search through all blocks to find one with matching hash that is canonical
     for (const [, block] of this.blocks) {
       if (block.blockHash === blockHash && block.isCanonical) {
         return block;
@@ -85,26 +93,18 @@ export class BlockchainStateService {
     return null;
   }
 
-  /**
-   * Store a pending event
-   */
   async savePendingEvent(event: PendingEvent): Promise<void> {
     this.events.set(event.id, event);
     if (event.status === 'pending') {
       this.chainState.pendingEventCount++;
     }
+    this.evictOldEvents();
   }
 
-  /**
-   * Get event by ID
-   */
   async getEvent(eventId: string): Promise<PendingEvent | null> {
     return this.events.get(eventId) || null;
   }
 
-  /**
-   * Get all events at a specific block
-   */
   async getEventsByBlock(blockNumber: number): Promise<PendingEvent[]> {
     const blockEvents: PendingEvent[] = [];
     this.events.forEach((event) => {
@@ -115,9 +115,6 @@ export class BlockchainStateService {
     return blockEvents;
   }
 
-  /**
-   * Get all pending events
-   */
   async getPendingEvents(): Promise<PendingEvent[]> {
     const pending: PendingEvent[] = [];
     this.events.forEach((event) => {
@@ -128,9 +125,6 @@ export class BlockchainStateService {
     return pending;
   }
 
-  /**
-   * Get all orphaned events
-   */
   async getOrphanedEvents(): Promise<PendingEvent[]> {
     const orphaned: PendingEvent[] = [];
     this.events.forEach((event) => {
@@ -141,9 +135,6 @@ export class BlockchainStateService {
     return orphaned;
   }
 
-  /**
-   * Update event status
-   */
   async updateEventStatus(
     eventId: string,
     status: 'pending' | 'confirmed' | 'orphaned',
@@ -171,9 +162,6 @@ export class BlockchainStateService {
     }
   }
 
-  /**
-   * Mark blocks as non-canonical (used during reorg detection)
-   */
   async markBlocksNonCanonical(blockNumbers: number[]): Promise<void> {
     this.blocks.forEach((block) => {
       if (blockNumbers.includes(block.blockNumber)) {
@@ -182,38 +170,24 @@ export class BlockchainStateService {
     });
   }
 
-  /**
-   * Record a reorg event
-   */
   async recordReorg(reorg: ReorgEvent): Promise<void> {
     this.reorgHistory.push(reorg);
     this.chainState.lastReorgTime = reorg.detectedAt;
+    this.trimReorgHistory();
   }
 
-  /**
-   * Get reorg history
-   */
   async getReorgHistory(): Promise<ReorgEvent[]> {
     return this.reorgHistory;
   }
 
-  /**
-   * Update chain state
-   */
   async updateChainState(partial: Partial<ChainState>): Promise<void> {
     this.chainState = { ...this.chainState, ...partial };
   }
 
-  /**
-   * Get current chain state
-   */
   async getChainState(): Promise<ChainState> {
     return { ...this.chainState };
   }
 
-  /**
-   * Delete events (used during reorg rollback)
-   */
   async deleteEvents(eventIds: string[]): Promise<void> {
     for (const id of eventIds) {
       const event = this.events.get(id);
@@ -228,9 +202,6 @@ export class BlockchainStateService {
     }
   }
 
-  /**
-   * Clear all state (useful for testing)
-   */
   async clearAllState(): Promise<void> {
     this.blocks.clear();
     this.events.clear();
@@ -242,5 +213,80 @@ export class BlockchainStateService {
       pendingEventCount: 0,
       orphanedEventCount: 0,
     };
+  }
+
+  async getMemoryStats(): Promise<StateMemoryStats> {
+    let confirmed = 0;
+    let pending = 0;
+    let orphaned = 0;
+    this.events.forEach((event) => {
+      if (event.status === 'confirmed') confirmed++;
+      else if (event.status === 'pending') pending++;
+      else if (event.status === 'orphaned') orphaned++;
+    });
+
+    return {
+      currentBlockCount: this.blocks.size,
+      currentEventCount: this.events.size,
+      currentReorgHistoryCount: this.reorgHistory.length,
+      maxBlocksInMemory: this.maxBlocksInMemory,
+      maxEventsInMemory: this.maxEventsInMemory,
+      maxReorgHistoryEntries: this.maxReorgHistoryEntries,
+      confirmedEventCount: confirmed,
+      pendingEventCount: pending,
+      orphanedEventCount: orphaned,
+    };
+  }
+
+  private evictOldBlocks(): void {
+    if (this.blocks.size <= this.maxBlocksInMemory) return;
+
+    const sorted: { id: string; blockNumber: number }[] = [];
+    this.blocks.forEach((block, id) => {
+      sorted.push({ id, blockNumber: block.blockNumber });
+    });
+
+    sorted.sort((a, b) => a.blockNumber - b.blockNumber);
+
+    const excess = this.blocks.size - this.maxBlocksInMemory;
+    for (let i = 0; i < excess; i++) {
+      this.blocks.delete(sorted[i].id);
+    }
+
+    this.logger.debug(`Evicted ${excess} old block(s) from memory`);
+  }
+
+  private evictOldEvents(): void {
+    if (this.events.size <= this.maxEventsInMemory) return;
+
+    const confirmed: { id: string; confirmedAt?: Date }[] = [];
+    this.events.forEach((event, id) => {
+      if (event.status === 'confirmed') {
+        confirmed.push({ id, confirmedAt: event.confirmedAt });
+      }
+    });
+
+    confirmed.sort((a, b) => {
+      if (!a.confirmedAt && !b.confirmedAt) return 0;
+      if (!a.confirmedAt) return -1;
+      if (!b.confirmedAt) return 1;
+      return a.confirmedAt.getTime() - b.confirmedAt.getTime();
+    });
+
+    const excess = this.events.size - this.maxEventsInMemory;
+    const toRemove = Math.min(excess, confirmed.length);
+    for (let i = 0; i < toRemove; i++) {
+      this.events.delete(confirmed[i].id);
+    }
+
+    if (toRemove > 0) {
+      this.logger.debug(`Evicted ${toRemove} old confirmed event(s) from memory`);
+    }
+  }
+
+  private trimReorgHistory(): void {
+    while (this.reorgHistory.length > this.maxReorgHistoryEntries) {
+      this.reorgHistory.shift();
+    }
   }
 }

--- a/src/blockchain/types.ts
+++ b/src/blockchain/types.ts
@@ -51,6 +51,18 @@ export interface ChainState {
   lastReorgTime?: Date;
 }
 
+export interface StateMemoryStats {
+  currentBlockCount: number;
+  currentEventCount: number;
+  currentReorgHistoryCount: number;
+  maxBlocksInMemory: number;
+  maxEventsInMemory: number;
+  maxReorgHistoryEntries: number;
+  confirmedEventCount: number;
+  pendingEventCount: number;
+  orphanedEventCount: number;
+}
+
 /**
  * Verification and Voting Types
  */

--- a/src/config/blockchain.config.ts
+++ b/src/config/blockchain.config.ts
@@ -6,4 +6,8 @@ export default registerAs('blockchain', () => ({
   contractAddress: process.env.REWARD_CONTRACT_ADDRESS,
   startBlock: parseInt(process.env.START_BLOCK || '0', 10),
   confirmations: parseInt(process.env.REQUIRED_CONFIRMATIONS || '12', 10),
+  // Memory limits for in-memory state service (prevents OOM)
+  maxBlocksInMemory: parseInt(process.env.BLOCKCHAIN_MAX_BLOCKS || '10000', 10),
+  maxEventsInMemory: parseInt(process.env.BLOCKCHAIN_MAX_EVENTS || '50000', 10),
+  maxReorgHistoryEntries: parseInt(process.env.BLOCKCHAIN_MAX_REORG_HISTORY || '1000', 10),
 }));


### PR DESCRIPTION
## Summary

Implements configurable memory limits on the `BlockchainStateService` in-memory state store to prevent OOM under sustained block production.

Closes #213 
**Ref:** Internal Ref #BE-213

## Problem

The `BlockchainStateService` stores all blocks, events, and reorg history in-memory using unbounded `Map` and `Array` structures (`src/blockchain/state.service.ts:16-19`). Under sustained block production or heavy reorg activity, these data structures grow without limit, leading to an Out-of-Memory (OOM) crash.

## Solution

Added three configurable memory limits with automatic eviction when thresholds are exceeded:

| Env Var | Default | Description |
|---|---|---|
| `BLOCKCHAIN_MAX_BLOCKS` | 10,000 | Max block records in memory |
| `BLOCKCHAIN_MAX_EVENTS` | 50,000 | Max events in memory (confirmed/pending/orphaned) |
| `BLOCKCHAIN_MAX_REORG_HISTORY` | 1,000 | Max reorg history entries |

### Eviction strategy

- **Blocks**: Oldest blocks (by block number) are evicted first, keeping the most recent blocks needed for reorg detection.
- **Events**: Only **confirmed** events are eligible for eviction, oldest by `confirmedAt` first. `pending` and `orphaned` events are **never** evicted — they are still in-flight and must be retained for correct reorg reconciliation.
- **Reorg history**: Oldest entries are trimmed when the limit is exceeded.

### Monitoring

Added `getMemoryStats()` method returning a `StateMemoryStats` object with current usage and limits for all three stores, including a breakdown of event counts by status.

### Configuration

Values are read from the `blockchain` config namespace via `ConfigService`, defaulting to the values above. Documented in `.env.example`.

## Changes

| File | Change |
|---|---|
| `src/blockchain/types.ts` | Added `StateMemoryStats` interface |
| `src/config/blockchain.config.ts` | Added 3 env var-backed config values |
| `src/blockchain/state.service.ts` | Constructor reads limits, eviction hooks in `saveBlock`/`savePendingEvent`/`recordReorg`, added `getMemoryStats()`, added `evictOldBlocks()`/`evictOldEvents()`/`trimReorgHistory()` |
| `src/blockchain/state.service.spec.ts` | 24 unit tests: default limits, custom limits, block/event/reorg eviction, protocol invariants (pending/orphaned never evicted, count consistency) |
| `.env.example` | Documented new env vars |

## Testing

```bash
# New tests
./node_modules/.bin/jest --testPathPattern="state.service.spec"
# 24 passed ✓

# Existing blockchain tests (no regressions)
./node_modules/.bin/jest --testPathPattern="blockchain"
# All passed ✓
```

### Test coverage includes

- Default memory limit configuration
- Custom limits via `ConfigService`
- Block eviction (oldest removed, newest retained)
- Event eviction (only confirmed evicted, pending/orphaned preserved)
- Confirmed events evicted oldest-first by `confirmedAt`
- Reorg history trimming (oldest removed)
- Protocol invariants: count consistency, non-negative counts, status totals match event total
- Correct behavior under normal load (no eviction when under limit)
