### PR TITLE
fix(sybil): make MIN_CLAIMS_FOR_ACCURACY_SCORE configurable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,13 @@ POLLING_INTERVAL_MS=12000
 INDEXED_CONTRACTS='[]'
 
 # ==============================================
+# Sybil Resistance Configuration
+# ==============================================
+# Minimum number of claims a user must have voted on before their
+# accuracy score contributes to their sybil resistance score.
+SYBIL_MIN_CLAIMS_FOR_ACCURACY_SCORE=5
+
+# ==============================================
 # Prisma Configuration (SQLite/LibSQL)
 # ==============================================
 # Used for user/wallet management (separate from TypeORM)

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { RewardsModule } from './rewards/rewards.module';
 import blockchainConfig from './config/blockchain.config';
+import sybilConfig from './config/sybil.config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BlockchainModule } from './blockchain/blockchain.module';
 import { DisputeModule } from './dispute/dispute.module';
@@ -218,7 +219,7 @@ async function createThrottlerStorage(configService: ConfigService): Promise<any
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [blockchainConfig, throttlerConfig],
+      load: [blockchainConfig, throttlerConfig, sybilConfig],
       envFilePath: ['.env.local', '.env'],
     }),
     TypeOrmModule.forRoot({

--- a/src/config/sybil.config.ts
+++ b/src/config/sybil.config.ts
@@ -1,0 +1,8 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('sybil', () => ({
+  minClaimsForAccuracyScore: parseInt(
+    process.env.SYBIL_MIN_CLAIMS_FOR_ACCURACY_SCORE ?? '5',
+    10,
+  ),
+}));

--- a/src/sybil-resistance/sybil-resistance.module.ts
+++ b/src/sybil-resistance/sybil-resistance.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { SybilResistanceService } from './sybil-resistance.service';
 import { SybilResistanceController } from './sybil-resistance.controller';
 import { SybilResistantVotingService } from './sybil-resistant-voting.service';
 import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ConfigModule],
   controllers: [SybilResistanceController],
   providers: [SybilResistanceService, SybilResistantVotingService],
   exports: [SybilResistanceService, SybilResistantVotingService],

--- a/src/sybil-resistance/sybil-resistance.service.spec.ts
+++ b/src/sybil-resistance/sybil-resistance.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { SybilResistanceService } from './sybil-resistance.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotFoundException } from '@nestjs/common';
@@ -6,6 +7,7 @@ import { NotFoundException } from '@nestjs/common';
 describe('SybilResistanceService', () => {
   let service: SybilResistanceService;
   let prisma: any;
+  let configService: ConfigService;
 
   // Mock user data
   const mockUserId = 'test-user-id';
@@ -44,11 +46,21 @@ describe('SybilResistanceService', () => {
             },
           },
         },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+              if (key === 'sybil.minClaimsForAccuracyScore') return defaultValue ?? 5;
+              return defaultValue;
+            }),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<SybilResistanceService>(SybilResistanceService);
     prisma = module.get<any>(PrismaService);
+    configService = module.get<ConfigService>(ConfigService);
   });
 
   afterEach(() => {
@@ -471,6 +483,105 @@ describe('SybilResistanceService', () => {
 
       expect(result[0].success).toBe(false);
       expect(result[0].error).toBe('Database error');
+    });
+  });
+
+  describe('MIN_CLAIMS_FOR_ACCURACY_SCORE configurability', () => {
+    async function buildServiceWithMinClaims(minClaims: number): Promise<SybilResistanceService> {
+      const mod = await Test.createTestingModule({
+        providers: [
+          SybilResistanceService,
+          {
+            provide: PrismaService,
+            useValue: {
+              user: { findUnique: jest.fn(), findMany: jest.fn(), update: jest.fn() },
+              sybilScore: { create: jest.fn(), findFirst: jest.fn(), findMany: jest.fn() },
+            },
+          },
+          {
+            provide: ConfigService,
+            useValue: {
+              get: (key: string, defaultValue?: any) =>
+                key === 'sybil.minClaimsForAccuracyScore' ? minClaims : defaultValue,
+            },
+          },
+        ],
+      }).compile();
+      return mod.get<SybilResistanceService>(SybilResistanceService);
+    }
+
+    it('should use the default threshold of 5 when env var is not overridden', () => {
+      // ConfigService mock returns default (5) — accuracy score is 0 for < 5 claims
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({
+        ...mockUser,
+        worldcoinVerified: false,
+        wallets: [],
+      });
+      // Access private field via any cast to verify initialization
+      expect((service as any).MIN_CLAIMS_FOR_ACCURACY_SCORE).toBe(5);
+    });
+
+    it('should read MIN_CLAIMS_FOR_ACCURACY_SCORE from ConfigService on construction', async () => {
+      const customService = await buildServiceWithMinClaims(10);
+      expect((customService as any).MIN_CLAIMS_FOR_ACCURACY_SCORE).toBe(10);
+    });
+
+    it('should not award accuracy score when claims voted on is below configured threshold', async () => {
+      const customService = await buildServiceWithMinClaims(10);
+      const prismaInCustom = (customService as any).prisma;
+
+      // Provide a user whose claimsVotedOn would be below threshold
+      jest.spyOn(prismaInCustom.user, 'findUnique').mockResolvedValue({
+        ...mockUser,
+        wallets: [],
+      });
+
+      const { details } = await customService.computeSybilScore(mockUserId);
+      expect(details.componentScores.accuracy).toBe(0);
+    });
+
+    it('should award accuracy score when claims voted on meets custom threshold', async () => {
+      // Use threshold of 3 and manually inject enough claims via gatherSignals override
+      const customService = await buildServiceWithMinClaims(3);
+      const prismaInCustom = (customService as any).prisma;
+
+      jest.spyOn(prismaInCustom.user, 'findUnique').mockResolvedValue({
+        ...mockUser,
+        wallets: [],
+      });
+
+      // Spy on private gatherSignals to inject 4 correct out of 4 votes (above threshold 3)
+      jest.spyOn(customService as any, 'gatherSignals').mockResolvedValue({
+        worldcoinVerified: false,
+        oldestWalletAgeMs: 0,
+        totalStakedAmount: BigInt(0),
+        claimsVotedOn: 4,
+        claimsCorrect: 4,
+      });
+
+      const { details } = await customService.computeSybilScore(mockUserId);
+      expect(details.componentScores.accuracy).toBe(1);
+    });
+
+    it('should treat boundary value (exactly equal to threshold) as meeting the threshold', async () => {
+      const customService = await buildServiceWithMinClaims(3);
+      const prismaInCustom = (customService as any).prisma;
+
+      jest.spyOn(prismaInCustom.user, 'findUnique').mockResolvedValue({
+        ...mockUser,
+        wallets: [],
+      });
+
+      jest.spyOn(customService as any, 'gatherSignals').mockResolvedValue({
+        worldcoinVerified: false,
+        oldestWalletAgeMs: 0,
+        totalStakedAmount: BigInt(0),
+        claimsVotedOn: 3, // exactly at threshold
+        claimsCorrect: 3,
+      });
+
+      const { details } = await customService.computeSybilScore(mockUserId);
+      expect(details.componentScores.accuracy).toBe(1);
     });
   });
 

--- a/src/sybil-resistance/sybil-resistance.service.ts
+++ b/src/sybil-resistance/sybil-resistance.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
 
 /**
@@ -41,9 +42,17 @@ export class SybilResistanceService {
   // Scoring thresholds and normalization constants
   private readonly WALLET_AGE_THRESHOLD_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
   private readonly MIN_STAKING_FOR_FULL_SCORE = BigInt('1000000000000000000'); // 1 token (assuming 18 decimals)
-  private readonly MIN_CLAIMS_FOR_ACCURACY_SCORE = 5;
+  private readonly MIN_CLAIMS_FOR_ACCURACY_SCORE: number;
 
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private configService: ConfigService,
+  ) {
+    this.MIN_CLAIMS_FOR_ACCURACY_SCORE = this.configService.get<number>(
+      'sybil.minClaimsForAccuracyScore',
+      5,
+    );
+  }
 
   /**
    * Compute Sybil resistance score for a user


### PR DESCRIPTION
Hardcoded threshold of 5 claims identified in audit (BE-215). Now reads SYBIL_MIN_CLAIMS_FOR_ACCURACY_SCORE from environment via ConfigService, defaulting to 5 when unset. Adds sybil.config.ts namespace, wires ConfigModule into SybilResistanceModule, and covers the new behaviour with unit tests for default, custom, below-, at-, and above-threshold cases.

resolves #215