### PR TITLE
 Inconsistent BigInt serialization

### DIFF
--- a/src/blockchain/event-indexing.service.ts
+++ b/src/blockchain/event-indexing.service.ts
@@ -3,6 +3,7 @@ import { BlockchainStateService } from './state.service';
 import { ReorgDetectorService } from './reorg-detector.service';
 import { ReconciliationService } from './reconciliation.service';
 import { BlockInfo, PendingEvent } from './types';
+import { serializeBigInts } from '../common/utils/bigint-serialization.util';
 
 /**
  * Event indexing service with confirmation strategy
@@ -87,7 +88,7 @@ export class EventIndexingService {
       blockNumber: block.number,
       blockHash: block.hash,
       eventType: event.type || 'unknown',
-      data: event.data || {},
+      data: serializeBigInts(event.data || {}) as Record<string, any>,
       transactionHash: event.transactionHash,
       logIndex: event.logIndex || 0,
       status: 'pending',

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from './guards/wallet-throttler.guard';
 export * from './decorators/throttle-by-wallet.decorator';
+export * from './utils/bigint-serialization.util';

--- a/src/common/utils/bigint-serialization.util.spec.ts
+++ b/src/common/utils/bigint-serialization.util.spec.ts
@@ -1,0 +1,34 @@
+import { serializeBigInts } from './bigint-serialization.util';
+
+describe('serializeBigInts', () => {
+  it('serializes nested BigInt values as decimal strings', () => {
+    const serialized = serializeBigInts({
+      amount: 9007199254740993n,
+      nested: {
+        values: [1n, 2n],
+      },
+    });
+
+    expect(serialized).toEqual({
+      amount: '9007199254740993',
+      nested: {
+        values: ['1', '2'],
+      },
+    });
+    expect(() => JSON.stringify(serialized)).not.toThrow();
+  });
+
+  it('serializes ethers-style Result objects through toObject', () => {
+    const resultLike = {
+      toObject: () => ({
+        user: '0x0000000000000000000000000000000000000001',
+        amount: 123456789012345678901234567890n,
+      }),
+    };
+
+    expect(serializeBigInts(resultLike)).toEqual({
+      user: '0x0000000000000000000000000000000000000001',
+      amount: '123456789012345678901234567890',
+    });
+  });
+});

--- a/src/common/utils/bigint-serialization.util.ts
+++ b/src/common/utils/bigint-serialization.util.ts
@@ -1,0 +1,92 @@
+type JsonSafeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Date
+  | JsonSafeValue[]
+  | { [key: string]: JsonSafeValue };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNumericKey(key: string): boolean {
+  return String(Number(key)) === key;
+}
+
+/**
+ * Recursively converts native BigInt values into decimal strings so blockchain
+ * amounts remain exact across JSON persistence and API responses.
+ */
+export function serializeBigInts<T>(value: T): JsonSafeValue {
+  return serializeBigIntsInternal(value, new WeakSet<object>());
+}
+
+function serializeBigIntsInternal(
+  value: unknown,
+  seen: WeakSet<object>,
+): JsonSafeValue {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (!isObject(value)) {
+    return null;
+  }
+
+  if (seen.has(value)) {
+    throw new TypeError(
+      'Cannot serialize circular structure with BigInt values',
+    );
+  }
+
+  seen.add(value);
+
+  const maybeResult = value as { toObject?: () => Record<string, unknown> };
+  if (typeof maybeResult.toObject === 'function') {
+    try {
+      const serializedResult = serializeBigIntsInternal(
+        maybeResult.toObject(),
+        seen,
+      );
+      seen.delete(value);
+      return serializedResult;
+    } catch {
+      // Fall back to enumerable keys for array-like decoded results.
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const serializedArray = value.map((item) =>
+      serializeBigIntsInternal(item, seen),
+    ) as JsonSafeValue[];
+    seen.delete(value);
+    return serializedArray;
+  }
+
+  const serializedObject: { [key: string]: JsonSafeValue } = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (isNumericKey(key)) {
+      continue;
+    }
+
+    serializedObject[key] = serializeBigIntsInternal(nestedValue, seen);
+  }
+
+  seen.delete(value);
+  return serializedObject;
+}

--- a/src/indexer/event-indexer.service.spec.ts
+++ b/src/indexer/event-indexer.service.spec.ts
@@ -1,14 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Repository } from 'typeorm';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { ethers, EventLog } from 'ethers';
 import { EventIndexerService } from './event-indexer.service';
-import { IndexedEvent, IndexingState } from '../entities';
 import { EventIndexerConfig } from '../config';
 
 describe('EventIndexerService', () => {
   let service: EventIndexerService;
-  let eventRepository: Repository<IndexedEvent>;
-  let stateRepository: Repository<IndexingState>;
+  let eventRepository: {
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+  };
+  let stateRepository: {
+    findOne: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+  };
   let mockConfig: EventIndexerConfig;
 
   beforeEach(async () => {
@@ -22,14 +29,26 @@ describe('EventIndexerService', () => {
       contracts: [],
     };
 
+    eventRepository = {
+      findOne: jest.fn(),
+      create: jest.fn((event) => event),
+      save: jest.fn(),
+      find: jest.fn(),
+    };
+    stateRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
           provide: EventIndexerService,
           useValue: new EventIndexerService(
             mockConfig,
-            {} as Repository<IndexedEvent>,
-            {} as Repository<IndexingState>,
+            eventRepository as any,
+            stateRepository as any,
           ),
         },
       ],
@@ -54,9 +73,59 @@ describe('EventIndexerService', () => {
 
   describe('backfillFromBlock', () => {
     it('should throw error if contract not found', async () => {
+      stateRepository.findOne.mockResolvedValue(null);
+
       await expect(
-        service.backfillFromBlock('0x0000000000000000000000000000000000000000', 1000),
+        service.backfillFromBlock(
+          '0x0000000000000000000000000000000000000000',
+          1000,
+        ),
       ).rejects.toThrow();
+    });
+  });
+
+  describe('processEvent', () => {
+    it('serializes decoded BigInt event args as decimal strings before persistence', async () => {
+      const iface = new ethers.Interface([
+        'event Transfer(address indexed from, address indexed to, uint256 amount)',
+      ]);
+      const encoded = iface.encodeEventLog(iface.getEvent('Transfer')!, [
+        '0x0000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000002',
+        9007199254740993n,
+      ]);
+      const log = {
+        transactionHash: '0x' + 'a'.repeat(64),
+        blockNumber: 100,
+        index: 2,
+        topics: encoded.topics,
+        data: encoded.data,
+      } as unknown as EventLog;
+
+      eventRepository.findOne.mockResolvedValue(null);
+      (service as any).provider = {
+        getBlock: jest.fn().mockResolvedValue({ number: 100 }),
+      };
+
+      await (service as any).processEvent(
+        '0x0000000000000000000000000000000000000003',
+        {
+          name: 'Transfer',
+          abi: 'event Transfer(address indexed from, address indexed to, uint256 amount)',
+        },
+        log,
+        120,
+      );
+
+      const persistedEvent = eventRepository.create.mock.calls[0][0];
+
+      expect(persistedEvent.parsedData).toMatchObject({
+        from: '0x0000000000000000000000000000000000000001',
+        to: '0x0000000000000000000000000000000000000002',
+        amount: '9007199254740993',
+      });
+      expect(() => JSON.stringify(persistedEvent.parsedData)).not.toThrow();
+      expect(eventRepository.save).toHaveBeenCalledWith(persistedEvent);
     });
   });
 });

--- a/src/indexer/event-indexer.service.ts
+++ b/src/indexer/event-indexer.service.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { ethers, EventLog } from 'ethers';
 import { IndexedEvent, IndexingState } from '../entities';
 import { EventIndexerConfig } from '../config';
+import { serializeBigInts } from '../common/utils/bigint-serialization.util';
 
 /**
  * Core event indexing service
@@ -251,8 +252,8 @@ export class EventIndexerService {
         blockNumber: log.blockNumber,
         logIndex: log.index,
         chainId: this.config.chainId,
-        eventData: log,
-        parsedData: parsed?.args || {},
+        eventData: serializeBigInts(log) as Record<string, any>,
+        parsedData: serializeBigInts(parsed?.args || {}) as Record<string, any>,
         confirmations,
         isFinalized: confirmations >= this.config.confirmationsRequired,
         isProcessed: false,


### PR DESCRIPTION
Close #179 

## Summary of the issue
Blockchain event decoding was inconsistently handling native BigInt values from ethers v6, especially for protocol amounts such as uint256 token/stake/reward values.

## Root cause
The event indexer persisted `parsed?.args` from ethers directly into JSON-backed fields. Ethers returns decoded integer values as native `bigint`, which is not JSON-serializable and must not be coerced through JavaScript `number` because large amounts exceed safe integer precision.

## Solution implemented
Added a shared BigInt serialization utility that recursively converts native `bigint` values to exact decimal strings before JSON persistence or response exposure. Wired this into indexed event persistence and pending blockchain event storage.

## Key changes made
- Added `serializeBigInts` utility for JSON-safe BigInt normalization.
- Normalized `eventData` and `parsedData` in the event indexer before saving.
- Normalized pending blockchain event payload data.
- Added unit tests for nested BigInt serialization and ethers-style decoded event args.
- Strengthened the indexer test to verify a `uint256` above `Number.MAX_SAFE_INTEGER` persists as an exact string.

## Trade-offs or considerations
BigInt values are serialized as decimal strings, matching existing protocol DTO conventions for amount fields and avoiding precision loss. Numeric JSON fields that are already safe numbers remain unchanged.

## Testing steps
- `npm.cmd test -- --runTestsByPath src/common/utils/bigint-serialization.util.spec.ts src/indexer/event-indexer.service.spec.ts`
- `npm.cmd test -- --runTestsByPath src/blockchain/blockchain-indexer.service.spec.ts`

