### PR TITLE
Fix indexer checkpoint desync: save checkpoint after successful commi…

### DIFF
--- a/src/blockchain/blockchain-indexer.service.spec.ts
+++ b/src/blockchain/blockchain-indexer.service.spec.ts
@@ -84,7 +84,40 @@ describe('BlockchainIndexerService', () => {
       expect(processedEventRepo.findOne).toHaveBeenCalledWith({
         where: { txHash: event.txHash, logIndex: event.logIndex, blockNumber: event.blockNumber },
       });
-      expect(mockQueryRunner.manager.save).toHaveBeenCalled();
+      expect(mockQueryRunner.manager.save).toHaveBeenCalledWith(ProcessedEvent, expect.objectContaining({ txHash: event.txHash }));
+      expect(mockQueryRunner.manager.save).toHaveBeenCalledWith(IndexerCheckpoint, expect.objectContaining({ lastBlock: 100, id: 1 }));
+    });
+
+    it('should create checkpoint when none exists', async () => {
+      const event: BlockchainEvent = {
+        txHash: '0xabc',
+        logIndex: 1,
+        blockNumber: 101,
+        eventType: 'Transfer',
+        data: { from: '0xa', to: '0xb', amount: '200', token: '0xc' },
+      };
+
+      jest.spyOn(processedEventRepo, 'findOne').mockResolvedValue(null);
+      jest.spyOn(processedEventRepo, 'create').mockReturnValue(event as any);
+
+      const mockQueryRunner = {
+        connect: jest.fn(),
+        startTransaction: jest.fn(),
+        commitTransaction: jest.fn(),
+        rollbackTransaction: jest.fn(),
+        release: jest.fn(),
+        manager: {
+          save: jest.fn().mockResolvedValue({}),
+          decrement: jest.fn().mockResolvedValue({ affected: 1 }),
+          increment: jest.fn().mockResolvedValue({ affected: 1 }),
+          findOne: jest.fn().mockResolvedValue(null),
+        },
+      };
+      jest.spyOn(dataSource, 'createQueryRunner').mockReturnValue(mockQueryRunner as any);
+
+      await service.processEvent(event);
+
+      expect(mockQueryRunner.manager.save).toHaveBeenCalledWith(IndexerCheckpoint, expect.objectContaining({ lastBlock: 101, id: 1 }));
     });
 
     it('should skip already processed event', async () => {

--- a/src/blockchain/blockchain-indexer.service.ts
+++ b/src/blockchain/blockchain-indexer.service.ts
@@ -53,21 +53,12 @@ export class BlockchainIndexerService {
         await this.updateBalances(queryRunner.manager, data as TransferEventData);
       }
 
-      // Update checkpoint
-      await queryRunner.manager.update(
-        IndexerCheckpoint,
-        { id: 1 },
-        {
-          lastBlock: Math.max(
-            (await this.getLastBlock(queryRunner.manager)) || 0,
-            blockNumber,
-          ),
-          updatedAt: new Date(),
-        },
-      );
-
       await queryRunner.commitTransaction();
       this.logger.log(`Processed event: ${eventType} at block ${blockNumber}`);
+
+      // Save checkpoint after successful commit to avoid checkpoint desyncs
+      // if the transaction is rolled back. Use repository (outside txn).
+      await this.saveCheckpointAfterCommit(blockNumber);
     } catch (error) {
       await queryRunner.rollbackTransaction();
       this.logger.error(`Failed to process event: ${error.message}`, error.stack);
@@ -90,6 +81,29 @@ export class BlockchainIndexerService {
   private async getLastBlock(manager: any): Promise<number | null> {
     const checkpoint = await manager.findOne(IndexerCheckpoint, { where: { id: 1 } });
     return checkpoint ? checkpoint.lastBlock : null;
+  }
+
+  private async saveCheckpoint(manager: any, blockNumber: number): Promise<void> {
+    const currentLastBlock = (await this.getLastBlock(manager)) || 0;
+    const nextLastBlock = Math.max(currentLastBlock, blockNumber);
+
+    await manager.save(IndexerCheckpoint, {
+      id: 1,
+      lastBlock: nextLastBlock,
+      updatedAt: new Date(),
+    });
+  }
+
+  private async saveCheckpointAfterCommit(blockNumber: number): Promise<void> {
+    const checkpoint = await this.checkpointRepo.findOne({ where: { id: 1 } });
+    const currentLastBlock = checkpoint ? checkpoint.lastBlock : 0;
+    const nextLastBlock = Math.max(currentLastBlock || 0, blockNumber);
+
+    await this.checkpointRepo.save({
+      id: 1,
+      lastBlock: nextLastBlock,
+      updatedAt: new Date(),
+    });
   }
 
   async replayFromBlock(startBlock: number): Promise<void> {

--- a/src/blockchain/blockchain-indexer.spec.ts
+++ b/src/blockchain/blockchain-indexer.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { BlockchainIndexerService } from './blockchain-indexer.service';
+import { ProcessedEvent } from './entities/processed-event.entity';
+import { TokenBalance } from './entities/token-balance.entity';
+import { IndexerCheckpoint } from './entities/indexer-checkpoint.entity';
+
+describe('BlockchainIndexerService - Checkpoint Commit Behavior', () => {
+  let service: BlockchainIndexerService;
+  let processedEventRepo: any;
+  let tokenBalanceRepo: any;
+  let checkpointRepo: any;
+  let dataSource: any;
+
+  beforeEach(async () => {
+    processedEventRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockImplementation((obj) => obj),
+    };
+
+    tokenBalanceRepo = {};
+
+    checkpointRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      save: jest.fn().mockResolvedValue(null),
+    };
+
+    const mockManager = {
+      save: jest.fn().mockResolvedValue(null),
+      decrement: jest.fn().mockResolvedValue(null),
+      increment: jest.fn().mockResolvedValue(null),
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+
+    const mockQueryRunner = {
+      connect: jest.fn().mockResolvedValue(null),
+      startTransaction: jest.fn().mockResolvedValue(null),
+      manager: mockManager,
+      commitTransaction: jest.fn().mockResolvedValue(null),
+      rollbackTransaction: jest.fn().mockResolvedValue(null),
+      release: jest.fn().mockResolvedValue(null),
+    };
+
+    dataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    } as unknown as DataSource;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BlockchainIndexerService,
+        { provide: getRepositoryToken(ProcessedEvent), useValue: processedEventRepo },
+        { provide: getRepositoryToken(TokenBalance), useValue: tokenBalanceRepo },
+        { provide: getRepositoryToken(IndexerCheckpoint), useValue: checkpointRepo },
+        { provide: DataSource, useValue: dataSource },
+      ],
+    }).compile();
+
+    service = module.get<BlockchainIndexerService>(BlockchainIndexerService);
+  });
+
+  it('saves checkpoint after commit when processing succeeds', async () => {
+    const event = { txHash: '0x1', logIndex: 0, blockNumber: 123, eventType: 'Transfer', data: { from: 'a', to: 'b', amount: 1, token: 'T' } } as any;
+
+    await service.processEvent(event);
+
+    expect(dataSource.createQueryRunner).toHaveBeenCalled();
+    // Repository.save should be called after commit
+    expect(checkpointRepo.save).toHaveBeenCalledTimes(1);
+    const saved = checkpointRepo.save.mock.calls[0][0];
+    expect(saved.id).toBe(1);
+    expect(saved.lastBlock).toBe(123);
+  });
+
+  it('does not save checkpoint when processing fails and rolls back', async () => {
+    // Make manager.save throw to trigger rollback
+    const failingManager = {
+      save: jest.fn().mockRejectedValue(new Error('db error')),
+      decrement: jest.fn(),
+      increment: jest.fn(),
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+
+    const failingQueryRunner = {
+      connect: jest.fn().mockResolvedValue(null),
+      startTransaction: jest.fn().mockResolvedValue(null),
+      manager: failingManager,
+      commitTransaction: jest.fn().mockResolvedValue(null),
+      rollbackTransaction: jest.fn().mockResolvedValue(null),
+      release: jest.fn().mockResolvedValue(null),
+    };
+
+    (dataSource.createQueryRunner as jest.Mock).mockReturnValueOnce(failingQueryRunner as any);
+
+    const event = { txHash: '0x2', logIndex: 0, blockNumber: 200, eventType: 'Transfer', data: { from: 'x', to: 'y', amount: 5, token: 'T' } } as any;
+
+    await expect(service.processEvent(event)).rejects.toThrow('db error');
+
+    // checkpointRepo.save should not be called because transaction rolled back
+    expect(checkpointRepo.save).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
…t and add regression tests

closes #180
## PR Summary

- Fixed indexer checkpoint desync by moving checkpoint persistence to after a successful transaction commit.
- Ensures checkpoint state is not updated when event processing rolls back.
- Added regression tests covering:
  - checkpoint save after successful `processEvent`
  - checkpoint not saved on transaction failure

> This resolves the bug where the checkpoint could advance even when batch processing failed, preventing stale or inconsistent replay state.
