### PR TITLE
feat(ipfs): sanitize gateway URLs to prevent XSS (BE-177)

### DIFF
--- a/src/ipfs/ipfs.service.gateway.spec.ts
+++ b/src/ipfs/ipfs.service.gateway.spec.ts
@@ -30,4 +30,21 @@ describe('IpfsService gateway sanitization', () => {
     const svc = new IpfsService(provider);
     expect(svc.getGatewayUrl('QmTest')).toBeUndefined();
   });
+
+  it('returns URL that contains the provided CID', () => {
+    const provider: any = { getUrl: (cid: string) => `https://gateway.example.com/ipfs/${cid}` };
+    const svc = new IpfsService(provider);
+    const out = svc.getGatewayUrl('QmExampleCid');
+    expect(out).toBeDefined();
+    expect(out).toContain('QmExampleCid');
+  });
+
+  it('trims provider strings and is idempotent', () => {
+    const provider: any = { getUrl: (_: string) => '  https://trim.example.com/ipfs/QmTrim  ' };
+    const svc = new IpfsService(provider);
+    const first = svc.getGatewayUrl('QmTrim');
+    const second = svc.getGatewayUrl('QmTrim');
+    expect(first).toBe('https://trim.example.com/ipfs/QmTrim');
+    expect(second).toBe(first);
+  });
 });

--- a/src/ipfs/ipfs.service.gateway.spec.ts
+++ b/src/ipfs/ipfs.service.gateway.spec.ts
@@ -1,0 +1,33 @@
+import { IpfsService } from './ipfs.service';
+
+describe('IpfsService gateway sanitization', () => {
+  it('allows https gateway URLs', () => {
+    const provider: any = { getUrl: (_cid: string) => 'https://ipfs.io/ipfs/QmTest' };
+    const svc = new IpfsService(provider);
+    expect(svc.getGatewayUrl('QmTest')).toBe('https://ipfs.io/ipfs/QmTest');
+  });
+
+  it('allows http gateway URLs', () => {
+    const provider: any = { getUrl: (_cid: string) => 'http://example.com/ipfs/QmTest' };
+    const svc = new IpfsService(provider);
+    expect(svc.getGatewayUrl('QmTest')).toBe('http://example.com/ipfs/QmTest');
+  });
+
+  it('rejects javascript: URLs', () => {
+    const provider: any = { getUrl: (_cid: string) => 'javascript:alert(1)' };
+    const svc = new IpfsService(provider);
+    expect(svc.getGatewayUrl('QmTest')).toBeUndefined();
+  });
+
+  it('rejects data: URLs', () => {
+    const provider: any = { getUrl: (_cid: string) => 'data:text/html,<svg/onload=alert(1)>' };
+    const svc = new IpfsService(provider);
+    expect(svc.getGatewayUrl('QmTest')).toBeUndefined();
+  });
+
+  it('rejects URLs with angle brackets or newlines', () => {
+    const provider: any = { getUrl: (_cid: string) => 'https://example.com/?q=<script>' };
+    const svc = new IpfsService(provider);
+    expect(svc.getGatewayUrl('QmTest')).toBeUndefined();
+  });
+});

--- a/src/ipfs/ipfs.service.ts
+++ b/src/ipfs/ipfs.service.ts
@@ -41,11 +41,14 @@ export class IpfsService {
    */
   private sanitizeGatewayUrl(urlStr: string): string | undefined {
     try {
-      // Disallow characters commonly used in XSS vectors in the raw provider string
-      const unsafePattern = /[<>\r\n]/;
-      if (unsafePattern.test(urlStr)) return undefined;
+      // Trim and disallow characters commonly used in XSS vectors in the raw provider string
+      const raw = typeof urlStr === 'string' ? urlStr.trim() : '';
+      if (!raw) return undefined;
 
-      const url = new URL(urlStr);
+      const unsafePattern = /[<>\r\n]/;
+      if (unsafePattern.test(raw)) return undefined;
+
+      const url = new URL(raw);
 
       // Only allow http(s)
       if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;

--- a/src/ipfs/ipfs.service.ts
+++ b/src/ipfs/ipfs.service.ts
@@ -41,14 +41,14 @@ export class IpfsService {
    */
   private sanitizeGatewayUrl(urlStr: string): string | undefined {
     try {
+      // Disallow characters commonly used in XSS vectors in the raw provider string
+      const unsafePattern = /[<>\r\n]/;
+      if (unsafePattern.test(urlStr)) return undefined;
+
       const url = new URL(urlStr);
 
       // Only allow http(s)
       if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
-
-      // Disallow characters commonly used in XSS vectors
-      const unsafePattern = /[<>\r\n]/;
-      if (unsafePattern.test(url.href)) return undefined;
 
       // Return normalized URL (this will percent-encode parts as needed)
       return url.toString();

--- a/src/ipfs/ipfs.service.ts
+++ b/src/ipfs/ipfs.service.ts
@@ -25,7 +25,36 @@ export class IpfsService {
   }
 
   getGatewayUrl(cid: string): string | undefined {
-    if (typeof this.provider.getUrl === 'function') return this.provider.getUrl(cid);
-    return undefined;
+    if (typeof this.provider.getUrl !== 'function') return undefined;
+
+    const raw = this.provider.getUrl(cid);
+    if (!raw) return undefined;
+
+    return this.sanitizeGatewayUrl(raw);
+  }
+
+  /**
+   * Sanitize a gateway URL returned by an IPFS provider.
+   * - Only allow http/https schemes
+   * - Reject URLs containing control characters or angle brackets
+   * - Return a normalized URL string or undefined for unsafe values
+   */
+  private sanitizeGatewayUrl(urlStr: string): string | undefined {
+    try {
+      const url = new URL(urlStr);
+
+      // Only allow http(s)
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+
+      // Disallow characters commonly used in XSS vectors
+      const unsafePattern = /[<>\r\n]/;
+      if (unsafePattern.test(url.href)) return undefined;
+
+      // Return normalized URL (this will percent-encode parts as needed)
+      return url.toString();
+    } catch (err) {
+      this.logger.warn(`Invalid gateway URL from provider: ${urlStr}`);
+      return undefined;
+    }
   }
 }


### PR DESCRIPTION
Summary
- Implement sanitization for IPFS provider gateway URLs to prevent XSS and unsafe schemes; add unit tests validating sanitization and protocol invariants.

What changed
- Trim and validate provider-returned gateway strings.
- Reject raw strings containing `<`, `>`, `\r`, or `\n`.
- Only allow `http:` and `https:` schemes; normalize via `URL` before returning.
- Add unit tests covering allowed schemes, unsafe schemes, encoded/unsafe characters, CID containment, trimming, and idempotency.

Files changed
- `src/ipfs/ipfs.service.ts`
- `src/ipfs/ipfs.service.gateway.spec.ts`

Testing (local)
1. Install dependencies:
```
npm ci
```

2. Run the gateway tests:
```
npm test -- --testPathPattern=ipfs.service.gateway.spec.ts -i
```

Acceptance criteria (verified)
- Implementation functional: gateway URLs sanitized.
- Unit tests added and pass locally (7/7 for the gateway spec).
- No regressions observed in the new tests (recommend full test/CI run before merge).

Security notes
- Mitigates common XSS bypasses by rejecting unsafe raw strings before parsing.
- Consider further hardening: hostname allowlist, CSP/response headers, stricter CID validation.

Related
- Issue: #177 / Internal Ref BE-177

This PR will: Closes #177
