### PR TITLE
Fix/evidence integrity async leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "ethers": "^6.16.0",
         "ioredis": "^5.9.3",
         "jsonwebtoken": "^9.0.3",
+        "multiformats": "^14.0.0",
         "nestjs-pino": "^4.1.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -3715,7 +3716,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
       "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3757,7 +3758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3774,7 +3774,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3791,7 +3790,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3808,7 +3806,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3825,7 +3822,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3842,7 +3838,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3859,7 +3854,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3876,7 +3870,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3893,7 +3886,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3910,7 +3902,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3924,14 +3915,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -11366,6 +11357,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ethers": "^6.16.0",
     "ioredis": "^5.9.3",
     "jsonwebtoken": "^9.0.3",
+    "multiformats": "^14.0.0",
     "nestjs-pino": "^4.1.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
@@ -102,6 +103,9 @@
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^multiformats/(.*)$": "<rootDir>/__mocks__/multiformats.js"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/src/__mocks__/multiformats.js
+++ b/src/__mocks__/multiformats.js
@@ -1,0 +1,10 @@
+// Stub for ESM-only multiformats package used in Jest tests.
+// The real implementation is mocked at the module level in tests that use cid-verifier.
+module.exports = {
+  CID: {
+    parse: jest.fn(),
+  },
+  sha256: {
+    digest: jest.fn(),
+  },
+};

--- a/src/common/middleware/evidence-integrity.middleware.spec.ts
+++ b/src/common/middleware/evidence-integrity.middleware.spec.ts
@@ -1,0 +1,101 @@
+import { EvidenceIntegrityMiddleware } from "./evidence-integrity.middleware";
+import * as cidVerifier from "../../storage/cid-verifier";
+
+describe("EvidenceIntegrityMiddleware", () => {
+  let middleware: EvidenceIntegrityMiddleware;
+  let mockReq: any;
+  let mockRes: any;
+  let mockNext: jest.Mock;
+
+  beforeEach(() => {
+    middleware = new EvidenceIntegrityMiddleware();
+    mockNext = jest.fn();
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  it("should call next() when no file is present", async () => {
+    mockReq = { body: { cid: "bafybeiabc123" } };
+    await middleware.use(mockReq, mockRes, mockNext);
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockRes.status).not.toHaveBeenCalled();
+  });
+
+  it("should call next() when no cid is present", async () => {
+    mockReq = { file: { buffer: Buffer.from("data") }, body: {} };
+    await middleware.use(mockReq, mockRes, mockNext);
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockRes.status).not.toHaveBeenCalled();
+  });
+
+  it("should call next() when both file and cid are absent", async () => {
+    mockReq = { body: {} };
+    await middleware.use(mockReq, mockRes, mockNext);
+    expect(mockNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call next() when CID integrity check passes", async () => {
+    mockReq = {
+      file: { buffer: Buffer.from("valid content") },
+      body: { cid: "bafybeiabc123" },
+    };
+    jest.spyOn(cidVerifier, "verifyCIDIntegrity").mockResolvedValue(true);
+
+    await middleware.use(mockReq, mockRes, mockNext);
+
+    expect(cidVerifier.verifyCIDIntegrity).toHaveBeenCalledWith(
+      mockReq.file.buffer,
+      mockReq.body.cid,
+    );
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockRes.status).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when CID integrity check fails", async () => {
+    mockReq = {
+      file: { buffer: Buffer.from("tampered content") },
+      body: { cid: "bafybeiabc123" },
+    };
+    jest.spyOn(cidVerifier, "verifyCIDIntegrity").mockResolvedValue(false);
+
+    await middleware.use(mockReq, mockRes, mockNext);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message: "Evidence integrity verification failed",
+    });
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it("should return 500 when verifyCIDIntegrity throws an error", async () => {
+    mockReq = {
+      file: { buffer: Buffer.from("content") },
+      body: { cid: "bafybeiabc123" },
+    };
+    jest
+      .spyOn(cidVerifier, "verifyCIDIntegrity")
+      .mockRejectedValue(new Error("Unexpected failure"));
+
+    await middleware.use(mockReq, mockRes, mockNext);
+
+    expect(mockRes.status).toHaveBeenCalledWith(500);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message: "Evidence integrity verification encountered an error",
+    });
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it("should not call next() after sending a 400 response", async () => {
+    mockReq = {
+      file: { buffer: Buffer.from("bad") },
+      body: { cid: "bafybeiabc123" },
+    };
+    jest.spyOn(cidVerifier, "verifyCIDIntegrity").mockResolvedValue(false);
+
+    await middleware.use(mockReq, mockRes, mockNext);
+
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+});

--- a/src/common/middleware/evidence-integrity.middleware.ts
+++ b/src/common/middleware/evidence-integrity.middleware.ts
@@ -5,26 +5,34 @@ import { verifyCIDIntegrity } from "../../storage/cid-verifier";
 export class EvidenceIntegrityMiddleware implements NestMiddleware {
   private readonly logger = new Logger(EvidenceIntegrityMiddleware.name);
 
-  use(req: any, res: any, next: () => void) {
+  async use(req: any, res: any, next: () => void): Promise<void> {
     const file = req.file;
-    const cid = req.body.cid;
+    const cid = req.body?.cid;
 
     if (!file || !cid) {
       return next();
     }
 
-    const isValid = verifyCIDIntegrity(file.buffer, cid);
+    try {
+      const isValid = await verifyCIDIntegrity(file.buffer, cid);
 
-    if (!isValid) {
-      this.logger.warn(
-        `Evidence hash mismatch detected. CID: ${cid}`
+      if (!isValid) {
+        this.logger.warn(`Evidence hash mismatch detected. CID: ${cid}`);
+        res.status(400).json({
+          message: "Evidence integrity verification failed",
+        });
+        return;
+      }
+
+      next();
+    } catch (error) {
+      this.logger.error(
+        `Evidence integrity check threw an error. CID: ${cid}`,
+        error instanceof Error ? error.stack : String(error),
       );
-
-      return res.status(400).json({
-        message: "Evidence integrity verification failed",
+      res.status(500).json({
+        message: "Evidence integrity verification encountered an error",
       });
     }
-
-    next();
   }
 }


### PR DESCRIPTION
verifyCIDIntegrity is an async function returning Promise<boolean>, but the middleware called it without await. This meant isValid was always a truthy Promise object — the integrity check never actually blocked tampered evidence uploads.

Changes
Made use() async and added await to the verifyCIDIntegrity call
Added try/catch to handle unexpected errors with a 500 response instead of an unhandled rejection
Added moduleNameMapper in Jest config to stub the ESM-only multiformats package for the test environment
Added 7 unit tests covering: no file, no CID, valid CID passes, invalid CID returns 400, thrown error returns 500, and next() not called after rejection
Tests
All 7 new tests pass. No regressions.

Closes #184