### PR TITLE
fix: resolve BlockchainEvent data field being too generic

### DIFF
--- a/src/blockchain/blockchain-indexer.service.spec.ts
+++ b/src/blockchain/blockchain-indexer.service.spec.ts
@@ -103,6 +103,23 @@ describe('BlockchainIndexerService', () => {
       expect(processedEventRepo.findOne).toHaveBeenCalled();
       // No further processing should occur
     });
+
+    it('should allow strongly typed event data using generics', () => {
+      const transferEvent: BlockchainEvent<{ from: string, to: string, amount: string, token: string }> = {
+        txHash: '0xabc',
+        logIndex: 1,
+        blockNumber: 101,
+        eventType: 'Transfer',
+        data: {
+          from: '0xsender',
+          to: '0xreceiver',
+          amount: '500',
+          token: '0xtoken',
+        },
+      };
+      
+      expect(transferEvent.data.amount).toBe('500');
+    });
   });
 
   describe('replayFromBlock', () => {

--- a/src/blockchain/interfaces/blockchain-event.interface.ts
+++ b/src/blockchain/interfaces/blockchain-event.interface.ts
@@ -1,9 +1,9 @@
-export interface BlockchainEvent {
+export interface BlockchainEvent<T = Record<string, any>> {
   txHash: string;
   logIndex: number;
   blockNumber: number;
   eventType: string;
-  data: any; // Flexible for different event types
+  data: T; // Flexible for different event types
 }
 
 export interface TransferEventData {


### PR DESCRIPTION
### Title: 
fix: resolve BlockchainEvent data field being too generic

### Description:

**What was done:**
- Refactored the `BlockchainEvent` interface in `src/blockchain/interfaces/blockchain-event.interface.ts` to accept a generic type parameter `<T = Record<string, any>>` for the `data` field, replacing the overly generic `any` type.
- Added a unit test in `src/blockchain/blockchain-indexer.service.spec.ts` to verify the strict typing of event data objects.

**Why it was done:**
- During an audit, it was identified that the `data` field inside `BlockchainEvent` was too generic (`any`), which bypassed TypeScript's strict type checking for varying event payloads (like `TransferEventData`). This change enforces type safety while maintaining backwards compatibility with a safe default.

**How it was verified:**
- Wrote and passed a unit test explicitly enforcing the generic assignment of a mocked transfer event data structure.
- Logic was manually verified to properly restrict types without causing regressions in the existing indexer service operations.

Closes #186
