### PR TITLE
feat: optimize prisma binary targets and transition docker base to no…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+coverage
+dist
+.env
+.DS_Store
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+test
+.vscode
+npm-debug.log
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Node LTS
-FROM node:20-alpine
+FROM node:20-alpine AS builder
 
 # Set working directory
 WORKDIR /app
@@ -8,14 +8,24 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 
-# Copy project
+# Copy project sources and generate Prisma client
 COPY . .
-
-# Generate Prisma client
 RUN npx prisma generate
 
 # Build app
 RUN npm run build
+
+# Keep only production dependencies
+RUN npm prune --production
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src/generated ./src/generated
 
 # Expose port
 EXPOSE 3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,9 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=20 <21"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -3715,7 +3718,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
       "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3757,7 +3760,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3774,7 +3776,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3791,7 +3792,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3808,7 +3808,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3825,7 +3824,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3842,7 +3840,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3859,7 +3856,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3876,7 +3872,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3893,7 +3888,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3910,7 +3904,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3924,14 +3917,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": ">=20 <21"
+  },
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,6 +4,7 @@
 generator client {
   provider = "prisma-client"
   output   = "../src/generated/client"
+  binaryTargets = ["native", "linux-musl"]
 }
 
 datasource db {

--- a/src/dockerfile.spec.ts
+++ b/src/dockerfile.spec.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('Docker build configuration', () => {
+  const root = join(__dirname, '..');
+  const dockerfile = readFileSync(join(root, 'Dockerfile'), 'utf8');
+  const schema = readFileSync(join(root, 'prisma', 'schema.prisma'), 'utf8');
+  const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+
+  it('uses node:20-alpine for both build and runtime stages', () => {
+    expect(dockerfile).toContain('FROM node:20-alpine AS builder');
+    expect(dockerfile).toContain('FROM node:20-alpine AS runner');
+  });
+
+  it('prunes development dependencies after build', () => {
+    expect(dockerfile).toMatch(/npm prune --production/);
+  });
+
+  it('copies built dist artifacts and generated Prisma client into the final image', () => {
+    expect(dockerfile).toContain('COPY --from=builder /app/dist ./dist');
+    expect(dockerfile).toContain('COPY --from=builder /app/src/generated ./src/generated');
+  });
+
+  it('restricts Prisma engine binaries for Linux musl builds', () => {
+    expect(schema).toContain('binaryTargets = ["native", "linux-musl"]');
+  });
+
+  it('declares a Node engine version constraint in package.json', () => {
+    expect(packageJson.engines).toBeDefined();
+    expect(packageJson.engines.node).toBe('>=20 <21');
+  });
+});


### PR DESCRIPTION
…de:alpine
closes #192 
## Submission Description

Updated Docker and Prisma build configuration to reduce Prisma binary footprint in Docker and enforce Alpine-compatible engine targets.

### What changed
- Converted Dockerfile to a multi-stage `node:20-alpine` build
- Added `npm prune --production` in builder stage to remove dev dependencies from final image
- Restricted Prisma client engine binaries in schema.prisma with:
  - `binaryTargets = ["native", "linux-musl"]`
- Added `engines.node = ">=20 <21"` to package.json
- Added .dockerignore to reduce Docker build context
- Added a Jest regression test in dockerfile.spec.ts to verify build config and Prisma engine settings

### Why
- Minimize Docker image size by avoiding unnecessary runtime artifacts
- Ensure Prisma generates only Alpine-compatible binaries for Docker
- Lock Node version compatibility to the intended runtime environment
- Provide automated verification that Docker/Prisma config remains correct

### Verification
- Ran `npm install --ignore-engines --no-audit --no-fund`
- Executed dockerfile.spec.ts
- Result: `1 passed, 5 passed, 5 total`

### Summary
This change addresses the Prisma binary size issue in Docker by optimizing the container build and restricting Prisma engines to Alpine-compatible output, while adding test coverage to prevent regressions.