### PR TITLE
fix(BE-219): set resolvedAt on claim resolution and finalization

### DIFF
--- a/src/claims/claim-resolution.service.spec.ts
+++ b/src/claims/claim-resolution.service.spec.ts
@@ -1,50 +1,252 @@
-import { ClaimResolutionService } from "./claim-resolution.service";
+import { NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { ClaimResolutionService, VoteWeightSummary } from './claim-resolution.service';
+import { Claim, ClaimState } from './entities/claim.entity';
+import { ClaimFactory } from './factories/claim.factory';
 
-const claimRepoStub = {
-  findOneBy: jest.fn(),
-  save: jest.fn(),
-};
+// ─── Shared stubs ────────────────────────────────────────────────────────────
 
-const claimsCacheStub = {
-  invalidateClaim: jest.fn(),
-};
+function makeClaimRepoStub(claim?: Claim) {
+  return {
+    findOneBy: jest.fn().mockResolvedValue(claim ?? null),
+    save: jest.fn().mockImplementation(async (entity: any) => entity),
+    count: jest.fn().mockResolvedValue(0),
+  };
+}
 
-describe('Confidence Scoring', () => {
-  const service = new ClaimResolutionService(claimRepoStub as any, claimsCacheStub as any);
+function makeClaimsCacheStub() {
+  return {
+    invalidateClaim: jest.fn().mockResolvedValue(undefined),
+  };
+}
 
-  it('returns high confidence for strong consensus', () => {
-    const score = service.computeConfidenceScore({
-      trueWeight: 180,
-      falseWeight: 20,
-    });
+function makeDataSourceStub(claimRepoStub: ReturnType<typeof makeClaimRepoStub>) {
+  return {
+    transaction: jest.fn().mockImplementation(async (cb: (manager: any) => Promise<any>) => {
+      const manager = { save: claimRepoStub.save };
+      return cb(manager);
+    }),
+  };
+}
 
-    expect(score).toBeGreaterThan(0.7);
+// ─── computeConfidenceScore ───────────────────────────────────────────────────
+
+describe('ClaimResolutionService.computeConfidenceScore', () => {
+  let claimRepoStub: ReturnType<typeof makeClaimRepoStub>;
+  let claimsCacheStub: ReturnType<typeof makeClaimsCacheStub>;
+  let dataSourceStub: ReturnType<typeof makeDataSourceStub>;
+  let service: ClaimResolutionService;
+
+  beforeEach(() => {
+    claimRepoStub = makeClaimRepoStub();
+    claimsCacheStub = makeClaimsCacheStub();
+    dataSourceStub = makeDataSourceStub(claimRepoStub);
+    service = new ClaimResolutionService(
+      claimRepoStub as any,
+      claimsCacheStub as any,
+      dataSourceStub as any,
+    );
   });
 
-  it('returns low confidence for split votes', () => {
-    const score = service.computeConfidenceScore({
-      trueWeight: 110,
-      falseWeight: 90,
-    });
+  it('returns high confidence score for strong consensus', () => {
+    const result = service.computeConfidenceScore({ trueWeight: 180, falseWeight: 20 });
 
-    expect(score).toBeLessThan(0.3);
+    expect(result).not.toBeNull();
+    expect(result!.score).toBeGreaterThan(0.7);
+    expect(result!.verdict).toBe('true');
   });
 
-  it('returns null for low participation', () => {
-    const score = service.computeConfidenceScore({
-      trueWeight: 30,
-      falseWeight: 20,
-    });
+  it('returns low confidence score for split votes', () => {
+    const result = service.computeConfidenceScore({ trueWeight: 110, falseWeight: 90 });
 
-    expect(score).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.score).toBeLessThan(0.3);
   });
 
-  it('returns zero for tie', () => {
-    const score = service.computeConfidenceScore({
-      trueWeight: 100,
-      falseWeight: 100,
-    });
+  it('returns null for low participation (below MIN_REQUIRED_WEIGHT)', () => {
+    const result = service.computeConfidenceScore({ trueWeight: 30, falseWeight: 20 });
 
-    expect(score).toBe(0);
+    expect(result).toBeNull();
+  });
+
+  it('returns score of 0 for an exact tie (margin is 0)', () => {
+    const result = service.computeConfidenceScore({ trueWeight: 100, falseWeight: 100 });
+
+    expect(result).not.toBeNull();
+    expect(result!.score).toBe(0);
+    expect(result!.verdict).toBe('inconclusive');
+  });
+
+  it('returns verdict "false" when false votes dominate', () => {
+    const result = service.computeConfidenceScore({ trueWeight: 20, falseWeight: 180 });
+
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe('false');
+    expect(result!.score).toBeGreaterThan(0.7);
+  });
+
+  it('caps participation factor at 1 when total greatly exceeds minimum', () => {
+    const result = service.computeConfidenceScore({ trueWeight: 900, falseWeight: 100 });
+
+    expect(result).not.toBeNull();
+    expect(result!.participation).toBe(1);
+  });
+
+  it('throws BadRequestException for negative vote weights', () => {
+    expect(() =>
+      service.computeConfidenceScore({ trueWeight: -10, falseWeight: 50 }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException for non-finite vote weights', () => {
+    expect(() =>
+      service.computeConfidenceScore({ trueWeight: Infinity, falseWeight: 50 }),
+    ).toThrow(BadRequestException);
+  });
+});
+
+// ─── resolveClaim ─────────────────────────────────────────────────────────────
+
+describe('ClaimResolutionService.resolveClaim', () => {
+  let service: ClaimResolutionService;
+  let claimRepoStub: ReturnType<typeof makeClaimRepoStub>;
+  let claimsCacheStub: ReturnType<typeof makeClaimsCacheStub>;
+  let dataSourceStub: ReturnType<typeof makeDataSourceStub>;
+
+  function buildService(claim?: Claim) {
+    claimRepoStub = makeClaimRepoStub(claim);
+    claimsCacheStub = makeClaimsCacheStub();
+    dataSourceStub = makeDataSourceStub(claimRepoStub);
+    service = new ClaimResolutionService(
+      claimRepoStub as any,
+      claimsCacheStub as any,
+      dataSourceStub as any,
+    );
+  }
+
+  it('throws NotFoundException when claim does not exist', async () => {
+    buildService(undefined);
+    await expect(
+      service.resolveClaim('missing-id', { trueWeight: 150, falseWeight: 50 }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws ConflictException when claim is already finalized', async () => {
+    const claim = ClaimFactory.createClaim({ finalized: true });
+    buildService(claim);
+
+    await expect(
+      service.resolveClaim(claim.id, { trueWeight: 150, falseWeight: 50 }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('throws BadRequestException for invalid (negative) vote weights', async () => {
+    const claim = ClaimFactory.createClaim({ finalized: false });
+    buildService(claim);
+
+    await expect(
+      service.resolveClaim(claim.id, { trueWeight: -1, falseWeight: 50 }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // ─── BE-219: resolvedAt invariants ──────────────────────────────────────
+
+  it('sets resolvedAt on the saved claim when sufficient votes exist (BE-219)', async () => {
+    const claim = ClaimFactory.createClaim({
+      resolvedVerdict: null,
+      confidenceScore: null,
+      finalized: false,
+      resolvedAt: null,
+    });
+    buildService(claim);
+
+    const before = new Date();
+    const result = await service.resolveClaim(claim.id, { trueWeight: 160, falseWeight: 40 });
+    const after = new Date();
+
+    expect(result.claim.resolvedAt).toBeInstanceOf(Date);
+    expect(result.claim.resolvedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(result.claim.resolvedAt!.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it('sets resolvedAt on the saved claim for the inconclusive (low participation) path (BE-219)', async () => {
+    const claim = ClaimFactory.createClaim({
+      resolvedVerdict: null,
+      confidenceScore: null,
+      finalized: false,
+      resolvedAt: null,
+    });
+    buildService(claim);
+
+    const before = new Date();
+    const result = await service.resolveClaim(claim.id, { trueWeight: 30, falseWeight: 20 });
+    const after = new Date();
+
+    // Confidence is null (insufficient participation) but resolvedAt must still be set
+    expect(result.confidence).toBeNull();
+    expect(result.claim.resolvedAt).toBeInstanceOf(Date);
+    expect(result.claim.resolvedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(result.claim.resolvedAt!.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it('resolvedAt in the return value matches the claim entity resolvedAt (BE-219)', async () => {
+    const claim = ClaimFactory.createClaim({
+      resolvedVerdict: null,
+      confidenceScore: null,
+      finalized: false,
+      resolvedAt: null,
+    });
+    buildService(claim);
+
+    const result = await service.resolveClaim(claim.id, { trueWeight: 150, falseWeight: 50 });
+
+    expect(result.resolvedAt).toBeInstanceOf(Date);
+    // The returned resolvedAt must match what was written onto the entity
+    expect(result.claim.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not overwrite an existing resolvedAt on a previously resolved claim (BE-219)', async () => {
+    const existingResolvedAt = new Date('2024-03-01T10:00:00Z');
+    // Simulate a claim that was already resolved but not yet finalized
+    const claim = ClaimFactory.createClaim({
+      resolvedVerdict: true,
+      confidenceScore: 0.80,
+      finalized: false,
+      resolvedAt: existingResolvedAt,
+    });
+    buildService(claim);
+
+    const result = await service.resolveClaim(claim.id, { trueWeight: 160, falseWeight: 40 });
+
+    // The original resolvedAt must be preserved — should not be overwritten
+    expect(result.claim.resolvedAt).toEqual(existingResolvedAt);
+  });
+
+  it('invalidates the claim cache after resolution (BE-219)', async () => {
+    const claim = ClaimFactory.createClaim({
+      resolvedVerdict: null,
+      confidenceScore: null,
+      finalized: false,
+      resolvedAt: null,
+    });
+    buildService(claim);
+
+    await service.resolveClaim(claim.id, { trueWeight: 150, falseWeight: 50 });
+
+    expect(claimsCacheStub.invalidateClaim).toHaveBeenCalledWith(claim.id);
+  });
+
+  it('returns the saved claim with finalized=true after sufficient votes (BE-219)', async () => {
+    const claim = ClaimFactory.createClaim({
+      resolvedVerdict: null,
+      confidenceScore: null,
+      finalized: false,
+      resolvedAt: null,
+    });
+    buildService(claim);
+
+    const result = await service.resolveClaim(claim.id, { trueWeight: 150, falseWeight: 50 });
+
+    expect(result.claim.finalized).toBe(true);
+    expect(result.claim.resolvedAt).not.toBeNull();
   });
 });

--- a/src/claims/claim-resolution.service.ts
+++ b/src/claims/claim-resolution.service.ts
@@ -132,6 +132,7 @@ export class ClaimResolutionService {
     const savedClaim = await this.dataSource.transaction(async (manager) => {
       if (confidence) {
         // Use transitionTo helper for validated state transition
+        // transitionTo also sets resolvedAt on first resolution
         claim.transitionTo(ClaimState.FINALIZED, {
           verdict: confidence.verdict === 'true',
           confidence: confidence.score,
@@ -142,9 +143,16 @@ export class ClaimResolutionService {
         claim.resolvedVerdict = null;
         claim.confidenceScore = null;
         claim.finalized = true;
+        // Set resolvedAt for the inconclusive path (only if not already set)
+        if (!claim.resolvedAt) {
+          claim.resolvedAt = resolvedAt;
+        }
       }
 
-      claim.resolvedAt = resolvedAt;
+      // Ensure resolvedAt is always set on any resolved/finalized claim
+      if (!claim.resolvedAt) {
+        claim.resolvedAt = resolvedAt;
+      }
 
       return manager.save(claim);
     });

--- a/src/claims/claims.service.spec.ts
+++ b/src/claims/claims.service.spec.ts
@@ -283,7 +283,7 @@ describe('ClaimsService', () => {
 
   describe('resolveClaim', () => {
     it('should resolve a claim with verdict and confidence score', async () => {
-      const claim = ClaimFactory.createClaim({ resolvedVerdict: null, confidenceScore: null });
+      const claim = ClaimFactory.createClaim({ resolvedVerdict: null, confidenceScore: null, resolvedAt: null });
       const verdict = true;
       const confidenceScore = 0.85;
 
@@ -302,7 +302,7 @@ describe('ClaimsService', () => {
     });
 
     it('should invalidate claims:latest cache when resolving a claim', async () => {
-      const claim = ClaimFactory.createClaim({ resolvedVerdict: null, confidenceScore: null });
+      const claim = ClaimFactory.createClaim({ resolvedVerdict: null, confidenceScore: null, resolvedAt: null });
       const verdict = false;
       const confidenceScore = 0.65;
 
@@ -323,7 +323,7 @@ describe('ClaimsService', () => {
     });
 
     it('should log audit trail when resolving a claim', async () => {
-      const claim = ClaimFactory.createClaim({ resolvedVerdict: null, confidenceScore: null });
+      const claim = ClaimFactory.createClaim({ resolvedVerdict: null, confidenceScore: null, resolvedAt: null });
       const verdict = true;
       const confidenceScore = 0.75;
       const userId = 'user-123';
@@ -336,6 +336,66 @@ describe('ClaimsService', () => {
       await service.resolveClaim(claim.id, verdict, confidenceScore, userId);
 
       expect(auditTrailService.log).toHaveBeenCalled();
+    });
+
+    // ─── BE-219: resolvedAt invariants ────────────────────────────────────
+    it('should set resolvedAt on the claim entity before saving (BE-219)', async () => {
+      const claim = ClaimFactory.createClaim({ resolvedVerdict: null, confidenceScore: null, resolvedAt: null });
+      const before = new Date();
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(claim);
+      // Capture the argument passed to save so we can inspect resolvedAt
+      const saveSpy = jest.spyOn(claimRepo, 'save').mockImplementation(async (entity: any) => entity);
+      jest.spyOn(claimsCache, 'invalidateClaim').mockResolvedValue(undefined);
+      jest.spyOn(auditTrailService, 'log').mockResolvedValue(undefined);
+
+      await service.resolveClaim(claim.id, true, 0.85);
+      const after = new Date();
+
+      const savedEntity = saveSpy.mock.calls[0][0] as any;
+      expect(savedEntity.resolvedAt).toBeInstanceOf(Date);
+      expect(savedEntity.resolvedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(savedEntity.resolvedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should not overwrite resolvedAt if claim was already resolved (BE-219)', async () => {
+      const existingResolvedAt = new Date('2024-01-01T00:00:00Z');
+      const claim = ClaimFactory.createClaim({
+        resolvedVerdict: true,
+        confidenceScore: 0.80,
+        resolvedAt: existingResolvedAt,
+      });
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(claim);
+      const saveSpy = jest.spyOn(claimRepo, 'save').mockImplementation(async (entity: any) => entity);
+      jest.spyOn(claimsCache, 'invalidateClaim').mockResolvedValue(undefined);
+      jest.spyOn(auditTrailService, 'log').mockResolvedValue(undefined);
+
+      await service.resolveClaim(claim.id, false, 0.90);
+
+      const savedEntity = saveSpy.mock.calls[0][0] as any;
+      // The original resolvedAt must not be overwritten
+      expect(savedEntity.resolvedAt).toEqual(existingResolvedAt);
+    });
+
+    it('new claim has resolvedAt === null before any resolution (BE-219)', async () => {
+      const createClaimDto = ClaimFactory.createCreateClaimDto();
+      const savedClaim = ClaimFactory.createClaim({
+        ...createClaimDto,
+        resolvedVerdict: null,
+        confidenceScore: null,
+        finalized: false,
+        resolvedAt: null,
+      });
+
+      jest.spyOn(claimRepo, 'create').mockReturnValue(savedClaim);
+      jest.spyOn(claimRepo, 'save').mockResolvedValue(savedClaim);
+      jest.spyOn(claimsCache, 'setClaim').mockResolvedValue(undefined);
+      jest.spyOn(redisService, 'del').mockResolvedValue(true);
+
+      const result = await service.createClaim(createClaimDto);
+
+      expect(result.resolvedAt).toBeNull();
     });
   });
 
@@ -387,6 +447,53 @@ describe('ClaimsService', () => {
       await service.finalizeClaim(claim.id, userId);
 
       expect(auditTrailService.log).toHaveBeenCalled();
+    });
+
+    // ─── BE-219: resolvedAt invariants on finalizeClaim ───────────────────
+    it('should preserve existing resolvedAt when finalizing an already-resolved claim (BE-219)', async () => {
+      const existingResolvedAt = new Date('2024-06-15T12:00:00Z');
+      const claim = ClaimFactory.createClaim({
+        resolvedVerdict: true,
+        confidenceScore: 0.80,
+        finalized: false,
+        resolvedAt: existingResolvedAt,
+      });
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(claim);
+      const saveSpy = jest.spyOn(claimRepo, 'save').mockImplementation(async (entity: any) => entity);
+      jest.spyOn(claimsCache, 'invalidateClaim').mockResolvedValue(undefined);
+      jest.spyOn(auditTrailService, 'log').mockResolvedValue(undefined);
+
+      await service.finalizeClaim(claim.id);
+
+      const savedEntity = saveSpy.mock.calls[0][0] as any;
+      // resolvedAt was already set when the claim was resolved; it must not change
+      expect(savedEntity.resolvedAt).toEqual(existingResolvedAt);
+      expect(savedEntity.finalized).toBe(true);
+    });
+
+    it('should set resolvedAt when directly finalizing a pending claim (PENDING → FINALIZED) (BE-219)', async () => {
+      const claim = ClaimFactory.createClaim({
+        resolvedVerdict: null,
+        confidenceScore: null,
+        finalized: false,
+        resolvedAt: null,
+      });
+      const before = new Date();
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(claim);
+      const saveSpy = jest.spyOn(claimRepo, 'save').mockImplementation(async (entity: any) => entity);
+      jest.spyOn(claimsCache, 'invalidateClaim').mockResolvedValue(undefined);
+      jest.spyOn(auditTrailService, 'log').mockResolvedValue(undefined);
+
+      // finalizeClaim calls transitionTo(FINALIZED) — without data, which throws for PENDING state
+      // This tests the guard: a PENDING → FINALIZED transition requires verdict + confidence
+      await expect(service.finalizeClaim(claim.id)).rejects.toThrow(
+        'PENDING → FINALIZED requires both verdict and confidence data',
+      );
+
+      // save must NOT have been called since the transition failed
+      expect(saveSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/claims/claims.service.ts
+++ b/src/claims/claims.service.ts
@@ -132,6 +132,7 @@ export class ClaimsService {
         const beforeState = { ...claim };
 
         // Use transitionTo helper for validated state transition
+        // transitionTo sets resolvedAt on the claim entity when first resolved
         claim.transitionTo(ClaimState.RESOLVED, {
             verdict,
             confidence: confidenceScore,
@@ -166,6 +167,7 @@ export class ClaimsService {
         const beforeState = { ...claim };
 
         // Use transitionTo helper for validated state transition
+        // transitionTo preserves resolvedAt if already set (RESOLVED → FINALIZED path)
         claim.transitionTo(ClaimState.FINALIZED);
 
         const updatedClaim = await this.claimRepo.save(claim);

--- a/src/claims/entities/claim.entity.spec.ts
+++ b/src/claims/entities/claim.entity.spec.ts
@@ -11,6 +11,7 @@ describe('Claim Entity', () => {
     claim.resolvedVerdict = null;
     claim.confidenceScore = null;
     claim.finalized = false;
+    claim.resolvedAt = null;
   });
 
   describe('getCurrentState', () => {
@@ -327,6 +328,91 @@ describe('Claim Entity', () => {
           confidence: 0.90,
         });
       }).toThrow('Cannot transition from FINALIZED state');
+    });
+  });
+
+  // ─── BE-219: resolvedAt invariant tests ──────────────────────────────────
+  describe('resolvedAt invariants (BE-219)', () => {
+    it('new claim has resolvedAt === null', () => {
+      expect(claim.resolvedAt).toBeNull();
+    });
+
+    it('PENDING → RESOLVED sets resolvedAt to a Date', () => {
+      const before = new Date();
+      claim.transitionTo(ClaimState.RESOLVED, { verdict: true, confidence: 0.85 });
+      const after = new Date();
+
+      expect(claim.resolvedAt).toBeInstanceOf(Date);
+      expect(claim.resolvedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(claim.resolvedAt!.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('PENDING → FINALIZED sets resolvedAt to a Date', () => {
+      const before = new Date();
+      claim.transitionTo(ClaimState.FINALIZED, { verdict: false, confidence: 0.92 });
+      const after = new Date();
+
+      expect(claim.resolvedAt).toBeInstanceOf(Date);
+      expect(claim.resolvedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(claim.resolvedAt!.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('RESOLVED → RESOLVED does not overwrite the original resolvedAt', () => {
+      claim.transitionTo(ClaimState.RESOLVED, { verdict: true, confidence: 0.80 });
+      const firstResolvedAt = claim.resolvedAt!;
+
+      claim.transitionTo(ClaimState.RESOLVED, { verdict: false, confidence: 0.90 });
+
+      expect(claim.resolvedAt).toEqual(firstResolvedAt);
+    });
+
+    it('RESOLVED → FINALIZED preserves the original resolvedAt', () => {
+      claim.transitionTo(ClaimState.RESOLVED, { verdict: true, confidence: 0.75 });
+      const firstResolvedAt = claim.resolvedAt!;
+
+      claim.transitionTo(ClaimState.FINALIZED);
+
+      expect(claim.resolvedAt).toEqual(firstResolvedAt);
+      expect(claim.finalized).toBe(true);
+    });
+
+    it('PENDING → RESOLVED → FINALIZED: resolvedAt is set once and preserved', () => {
+      claim.transitionTo(ClaimState.RESOLVED, { verdict: true, confidence: 0.70 });
+      const resolvedAtAfterResolution = claim.resolvedAt!;
+
+      expect(resolvedAtAfterResolution).toBeInstanceOf(Date);
+
+      claim.transitionTo(ClaimState.FINALIZED);
+
+      expect(claim.resolvedAt).toEqual(resolvedAtAfterResolution);
+    });
+
+    it('invalid transition from FINALIZED does not modify resolvedAt', () => {
+      claim.transitionTo(ClaimState.FINALIZED, { verdict: true, confidence: 0.85 });
+      const resolvedAtSnapshot = claim.resolvedAt!;
+
+      expect(() => {
+        claim.transitionTo(ClaimState.RESOLVED, { verdict: false, confidence: 0.50 });
+      }).toThrow('Cannot transition from FINALIZED state');
+
+      expect(claim.resolvedAt).toEqual(resolvedAtSnapshot);
+    });
+
+    it('a resolved claim (RESOLVED state) always has a non-null resolvedAt', () => {
+      claim.transitionTo(ClaimState.RESOLVED, { verdict: true, confidence: 0.80 });
+      expect(claim.getCurrentState()).toBe(ClaimState.RESOLVED);
+      expect(claim.resolvedAt).not.toBeNull();
+    });
+
+    it('a finalized claim always has a non-null resolvedAt', () => {
+      claim.transitionTo(ClaimState.FINALIZED, { verdict: false, confidence: 0.65 });
+      expect(claim.getCurrentState()).toBe(ClaimState.FINALIZED);
+      expect(claim.resolvedAt).not.toBeNull();
+    });
+
+    it('an unresolved (PENDING) claim always has a null resolvedAt', () => {
+      expect(claim.getCurrentState()).toBe(ClaimState.PENDING);
+      expect(claim.resolvedAt).toBeNull();
     });
   });
 });

--- a/src/claims/entities/claim.entity.ts
+++ b/src/claims/entities/claim.entity.ts
@@ -120,6 +120,10 @@ export class Claim {
           this.resolvedVerdict = data.verdict;
           this.confidenceScore = data.confidence;
           this.finalized = false;
+          // Set resolvedAt exactly once on first resolution
+          if (this.resolvedAt === null || this.resolvedAt === undefined) {
+            this.resolvedAt = new Date();
+          }
         } else if (currentState === ClaimState.RESOLVED) {
           // RESOLVED → RESOLVED: allow updating verdict/confidence
           if (data?.verdict !== undefined) {
@@ -128,6 +132,7 @@ export class Claim {
           if (data?.confidence !== undefined) {
             this.confidenceScore = data.confidence;
           }
+          // resolvedAt is already set; do not overwrite it
         }
         break;
 
@@ -142,6 +147,10 @@ export class Claim {
           this.resolvedVerdict = data.verdict;
           this.confidenceScore = data.confidence;
           this.finalized = true;
+          // Set resolvedAt exactly once — first time this claim is resolved
+          if (this.resolvedAt === null || this.resolvedAt === undefined) {
+            this.resolvedAt = new Date();
+          }
         } else if (currentState === ClaimState.RESOLVED) {
           // RESOLVED → FINALIZED: just set finalized flag
           // Optionally update verdict/confidence if provided
@@ -152,6 +161,7 @@ export class Claim {
             this.confidenceScore = data.confidence;
           }
           this.finalized = true;
+          // resolvedAt was already set when transitioning to RESOLVED; do not overwrite it
         }
         break;
 

--- a/src/claims/factories/claim.factory.ts
+++ b/src/claims/factories/claim.factory.ts
@@ -37,6 +37,7 @@ export class ClaimFactory {
       confidenceScore: Math.random() * 0.9 + 0.1,
       finalized: false,
       createdAt: new Date(),
+      resolvedAt: null,
       evidences: [],
       ...overrides,
     } as Claim;

--- a/src/migrations/1769700000000-AddResolvedAtToClaims.ts
+++ b/src/migrations/1769700000000-AddResolvedAtToClaims.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * BE-219 — Add missing resolvedAt column to the claims table.
+ *
+ * The Claim entity declared `resolvedAt: Date | null` but the original
+ * CreateUserAndWallet migration never added the column to the database.
+ * This migration closes that gap.
+ *
+ * Protocol invariants enforced:
+ *  - NULL  → claim is unresolved (PENDING state)
+ *  - NOT NULL → claim has been resolved or finalized at least once
+ */
+export class AddResolvedAtToClaims1769700000000 implements MigrationInterface {
+  name = 'AddResolvedAtToClaims1769700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add the column as nullable — existing rows will default to NULL (unresolved)
+    await queryRunner.query(
+      `ALTER TABLE "claims" ADD COLUMN IF NOT EXISTS "resolvedAt" TIMESTAMP NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "claims" DROP COLUMN IF EXISTS "resolvedAt"`,
+    );
+  }
+}


### PR DESCRIPTION
- Claim.transitionTo() now sets resolvedAt=new Date() on first PENDING→RESOLVED and PENDING→FINALIZED transitions, and preserves the existing value on all subsequent transitions (RESOLVED→RESOLVED, RESOLVED→FINALIZED, FINALIZED is immutable)
- ClaimResolutionService.resolveClaim() guards the inconclusive path so resolvedAt is always set and never overwritten if already present
- ClaimFactory.createClaim() initialises resolvedAt: null so test fixtures reflect the correct initial state
- Add migration 1769700000000-AddResolvedAtToClaims to add the missing resolvedAt column to the claims table in the database
- Add comprehensive unit tests covering:
    * new claim has resolvedAt === null
    * PENDING→RESOLVED sets resolvedAt exactly once
    * PENDING→FINALIZED sets resolvedAt exactly once
    * RESOLVED→RESOLVED does not overwrite resolvedAt
    * RESOLVED→FINALIZED preserves resolvedAt
    * inconclusive resolution path sets resolvedAt
    * invalid transitions from FINALIZED leave resolvedAt unchanged
    * fixed broken computeConfidenceScore tests (returned ConfidenceResult not a raw number)

Closes BE-219