### PR TITLE
Implement Governance API with proposal and voting endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,6 +32,7 @@ import { LoggingInterceptor } from './logger/logging.interceptor';
 import { AuthModule } from './auth/auth.module';
 import { GlobalAuthGuard } from './auth/global-auth.guard';
 import { MetricsModule } from './metrics/metrics.module';
+import { GovernanceModule } from './governance/governance.module';
 
 // In-memory storage for development (no Redis needed)
 class ThrottlerMemoryStorage {
@@ -283,6 +284,7 @@ async function createThrottlerStorage(configService: ConfigService): Promise<any
     AuditModule,
     ThemeModule,
     MetricsModule,
+    GovernanceModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/governance/dto/cast-vote.dto.ts
+++ b/src/governance/dto/cast-vote.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class CastVoteDto {
+  @ApiProperty({ description: 'Voter wallet address' })
+  @IsString()
+  @IsNotEmpty()
+  voter: string;
+
+  @ApiProperty({ description: 'Whether the voter supports the proposal' })
+  @IsBoolean()
+  support: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Voting weight',
+    minimum: 0,
+    maximum: 1000000,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1000000)
+  weight?: number;
+
+  @ApiPropertyOptional({ description: 'Additional metadata' })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/governance/dto/create-proposal.dto.ts
+++ b/src/governance/dto/create-proposal.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { ProposalCategory } from '../entities/proposal.entity';
+
+export class CreateProposalDto {
+  @ApiProperty({ description: 'Proposal title' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ description: 'Proposal description' })
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @ApiProperty({ description: 'Proposer wallet address' })
+  @IsString()
+  @IsNotEmpty()
+  proposer: string;
+
+  @ApiPropertyOptional({
+    enum: ProposalCategory,
+    description: 'Proposal category',
+  })
+  @IsOptional()
+  @IsEnum(ProposalCategory)
+  category?: ProposalCategory;
+
+  @ApiPropertyOptional({
+    description: 'Blockchain transaction hash',
+  })
+  @IsOptional()
+  @IsString()
+  blockchainTxHash?: string;
+
+  @ApiPropertyOptional({ description: 'Additional metadata' })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/governance/entities/proposal.entity.ts
+++ b/src/governance/entities/proposal.entity.ts
@@ -1,0 +1,120 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum ProposalStatus {
+  ACTIVE = 'ACTIVE',
+  PASSED = 'PASSED',
+  REJECTED = 'REJECTED',
+  EXECUTED = 'EXECUTED',
+  CANCELLED = 'CANCELLED',
+  PENDING = 'PENDING',
+}
+
+export enum ProposalCategory {
+  PROTOCOL_UPGRADE = 'PROTOCOL_UPGRADE',
+  TREASURY = 'TREASURY',
+  PARAMETER_CHANGE = 'PARAMETER_CHANGE',
+  GOVERNANCE = 'GOVERNANCE',
+  COMMUNITY = 'COMMUNITY',
+}
+
+@Entity('proposals')
+@Index(['status'])
+@Index(['category'])
+@Index(['proposer'])
+@Index(['createdAt'])
+@Index(['status', 'category'])
+export class Proposal {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 500 })
+  title: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ type: 'varchar' })
+  proposer: string;
+
+  @Column({
+    type: 'varchar',
+    default: ProposalStatus.PENDING,
+  })
+  status: ProposalStatus;
+
+  @Column({
+    type: 'varchar',
+    default: ProposalCategory.PROTOCOL_UPGRADE,
+  })
+  category: ProposalCategory;
+
+  @Column({ type: 'varchar', nullable: true })
+  blockchainTxHash: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  totalVotes: number;
+
+  @Column({ type: 'int', default: 0 })
+  votesFor: number;
+
+  @Column({ type: 'int', default: 0 })
+  votesAgainst: number;
+
+  @Column({ type: 'decimal', precision: 5, scale: 4, default: 0 })
+  participationRate: number;
+
+  @Column({ type: 'decimal', precision: 5, scale: 4, default: 0 })
+  quorumProgress: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  votingStartsAt: Date | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  votingEndsAt: Date | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  executedAt: Date | null;
+
+  @Column({ type: 'simple-json', default: {} })
+  metadata: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('votes')
+@Index(['proposalId'])
+@Index(['voter'])
+@Index(['proposalId', 'voter'], { unique: true })
+export class Vote {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  proposalId: string;
+
+  @Column()
+  voter: string;
+
+  @Column({ type: 'boolean' })
+  support: boolean;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  weight: number;
+
+  @Column({ type: 'simple-json', default: {} })
+  metadata: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/governance/governance.cache.ts
+++ b/src/governance/governance.cache.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from '../redis/redis.service';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class GovernanceCache {
+  private readonly logger = new Logger(GovernanceCache.name);
+  private readonly ttl: number;
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly configService: ConfigService,
+  ) {
+    this.ttl = this.configService.get<number>('CACHE_GOVERNANCE_TTL', 3600);
+  }
+
+  private getProposalKey(id: string): string {
+    return `governance:proposal:${id}`;
+  }
+
+  private getActiveProposalsKey(): string {
+    return 'governance:proposals:active';
+  }
+
+  private getAllProposalsKey(): string {
+    return 'governance:proposals:all';
+  }
+
+  private getStatsKey(): string {
+    return 'governance:stats';
+  }
+
+  private getVotesKey(proposalId: string): string {
+    return `governance:votes:${proposalId}`;
+  }
+
+  async getProposal(id: string): Promise<any | null> {
+    const data = await this.redisService.get(this.getProposalKey(id));
+    if (data) {
+      this.logger.debug(`Cache hit for governance proposal:${id}`);
+      try {
+        return JSON.parse(data);
+      } catch {
+        return null;
+      }
+    }
+    this.logger.debug(`Cache miss for governance proposal:${id}`);
+    return null;
+  }
+
+  async setProposal(id: string, proposal: any): Promise<void> {
+    await this.redisService.set(
+      this.getProposalKey(id),
+      JSON.stringify(proposal),
+      this.ttl,
+    );
+  }
+
+  async getActiveProposals(): Promise<any[] | null> {
+    const data = await this.redisService.get(this.getActiveProposalsKey());
+    if (data) {
+      this.logger.debug('Cache hit for governance:proposals:active');
+      try {
+        return JSON.parse(data);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  async setActiveProposals(proposals: any[]): Promise<void> {
+    await this.redisService.set(
+      this.getActiveProposalsKey(),
+      JSON.stringify(proposals),
+      this.ttl,
+    );
+  }
+
+  async getStats(): Promise<any | null> {
+    const data = await this.redisService.get(this.getStatsKey());
+    if (data) {
+      this.logger.debug('Cache hit for governance:stats');
+      try {
+        return JSON.parse(data);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  async setStats(stats: any): Promise<void> {
+    await this.redisService.set(
+      this.getStatsKey(),
+      JSON.stringify(stats),
+      this.ttl,
+    );
+  }
+
+  async getVotes(proposalId: string): Promise<any[] | null> {
+    const data = await this.redisService.get(this.getVotesKey(proposalId));
+    if (data) {
+      this.logger.debug(`Cache hit for governance:votes:${proposalId}`);
+      try {
+        return JSON.parse(data);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  async setVotes(proposalId: string, votes: any[]): Promise<void> {
+    await this.redisService.set(
+      this.getVotesKey(proposalId),
+      JSON.stringify(votes),
+      this.ttl,
+    );
+  }
+
+  async invalidateProposal(id: string): Promise<void> {
+    const promises = [
+      this.redisService.del(this.getProposalKey(id)),
+      this.redisService.del(this.getActiveProposalsKey()),
+      this.redisService.del(this.getAllProposalsKey()),
+      this.redisService.del(this.getStatsKey()),
+      this.redisService.del(this.getVotesKey(id)),
+    ];
+    await Promise.all(promises);
+    this.logger.debug(`Invalidated cache for governance proposal:${id}`);
+  }
+
+  async invalidateAll(): Promise<void> {
+    const promises = [
+      this.redisService.del(this.getActiveProposalsKey()),
+      this.redisService.del(this.getAllProposalsKey()),
+      this.redisService.del(this.getStatsKey()),
+    ];
+    await Promise.all(promises);
+    this.logger.debug('Invalidated all governance caches');
+  }
+}

--- a/src/governance/governance.controller.ts
+++ b/src/governance/governance.controller.ts
@@ -1,0 +1,162 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { GovernanceService } from './governance.service';
+import { CreateProposalDto } from './dto/create-proposal.dto';
+import { CastVoteDto } from './dto/cast-vote.dto';
+import {
+  ProposalStatus,
+  ProposalCategory,
+} from './entities/proposal.entity';
+import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
+
+@ApiTags('governance')
+@Controller('governance')
+export class GovernanceController {
+  constructor(private readonly governanceService: GovernanceService) {}
+
+  // ─── Proposals ────────────────────────────────────────────────────────
+
+  @Get('proposals')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'Get all proposals with optional filters' })
+  @ApiQuery({ name: 'status', required: false, enum: ProposalStatus })
+  @ApiQuery({ name: 'category', required: false, enum: ProposalCategory })
+  @ApiQuery({ name: 'proposer', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiQuery({
+    name: 'sort',
+    required: false,
+    enum: ['newest', 'oldest', 'most_votes', 'highest_participation'],
+  })
+  @ApiResponse({ status: 200, description: 'List of proposals' })
+  async findAll(
+    @Query('status') status?: ProposalStatus,
+    @Query('category') category?: ProposalCategory,
+    @Query('proposer') proposer?: string,
+    @Query('limit') limit?: number,
+    @Query('offset') offset?: number,
+    @Query('sort')
+    sort?: 'newest' | 'oldest' | 'most_votes' | 'highest_participation',
+  ) {
+    return this.governanceService.findAll({
+      status,
+      category,
+      proposer,
+      limit: limit ? +limit : undefined,
+      offset: offset ? +offset : undefined,
+      sort,
+    });
+  }
+
+  @Get('proposals/active')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'Get active proposals' })
+  @ApiResponse({ status: 200, description: 'List of active proposals' })
+  async findActive() {
+    return this.governanceService.findActive();
+  }
+
+  @Get('proposals/:id')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'Get a single proposal by ID' })
+  @ApiParam({ name: 'id', description: 'Proposal ID' })
+  @ApiResponse({ status: 200, description: 'Proposal details' })
+  @ApiResponse({ status: 404, description: 'Proposal not found' })
+  async findOne(@Param('id') id: string) {
+    return this.governanceService.findOne(id);
+  }
+
+  @Post('proposals')
+  @ApiOperation({ summary: 'Create a new proposal' })
+  @ApiResponse({ status: 201, description: 'Proposal created' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  async create(@Body() dto: CreateProposalDto) {
+    return this.governanceService.create({
+      title: dto.title,
+      description: dto.description,
+      proposer: dto.proposer,
+      category: dto.category,
+      blockchainTxHash: dto.blockchainTxHash,
+      metadata: dto.metadata,
+    });
+  }
+
+  @Patch('proposals/:id/activate')
+  @ApiOperation({ summary: 'Activate a pending proposal' })
+  @ApiParam({ name: 'id', description: 'Proposal ID' })
+  @ApiResponse({ status: 200, description: 'Proposal activated' })
+  @ApiResponse({ status: 400, description: 'Invalid status transition' })
+  @ApiResponse({ status: 404, description: 'Proposal not found' })
+  async activate(@Param('id') id: string) {
+    return this.governanceService.activate(id);
+  }
+
+  @Patch('proposals/:id/execute')
+  @ApiOperation({ summary: 'Execute a passed proposal' })
+  @ApiParam({ name: 'id', description: 'Proposal ID' })
+  @ApiResponse({ status: 200, description: 'Proposal executed' })
+  @ApiResponse({ status: 400, description: 'Invalid status transition' })
+  @ApiResponse({ status: 404, description: 'Proposal not found' })
+  async execute(@Param('id') id: string) {
+    return this.governanceService.execute(id);
+  }
+
+  @Patch('proposals/:id/cancel')
+  @ApiOperation({ summary: 'Cancel a proposal' })
+  @ApiParam({ name: 'id', description: 'Proposal ID' })
+  @ApiResponse({ status: 200, description: 'Proposal cancelled' })
+  @ApiResponse({ status: 400, description: 'Invalid status transition' })
+  @ApiResponse({ status: 404, description: 'Proposal not found' })
+  async cancel(@Param('id') id: string) {
+    return this.governanceService.cancel(id);
+  }
+
+  // ─── Voting ───────────────────────────────────────────────────────────
+
+  @Get('proposals/:id/votes')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'Get votes for a proposal' })
+  @ApiParam({ name: 'id', description: 'Proposal ID' })
+  @ApiResponse({ status: 200, description: 'List of votes' })
+  @ApiResponse({ status: 404, description: 'Proposal not found' })
+  async getVotes(@Param('id') id: string) {
+    return this.governanceService.getVotesForProposal(id);
+  }
+
+  @Post('proposals/:id/votes')
+  @ApiOperation({ summary: 'Cast a vote on a proposal' })
+  @ApiParam({ name: 'id', description: 'Proposal ID' })
+  @ApiResponse({ status: 201, description: 'Vote cast' })
+  @ApiResponse({ status: 400, description: 'Invalid vote data' })
+  @ApiResponse({ status: 404, description: 'Proposal not found' })
+  @ApiResponse({ status: 409, description: 'Already voted' })
+  async castVote(@Param('id') id: string, @Body() dto: CastVoteDto) {
+    return this.governanceService.castVote(
+      id,
+      dto.voter,
+      dto.support,
+      dto.weight,
+      dto.metadata,
+    );
+  }
+
+  // ─── Analytics ────────────────────────────────────────────────────────
+
+  @Get('stats')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({ summary: 'Get governance statistics' })
+  @ApiResponse({ status: 200, description: 'Governance stats' })
+  async getStats() {
+    return this.governanceService.getStats();
+  }
+}

--- a/src/governance/governance.module.ts
+++ b/src/governance/governance.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { GovernanceController } from './governance.controller';
+import { GovernanceService } from './governance.service';
+import { GovernanceCache } from './governance.cache';
+import { Proposal, Vote } from './entities/proposal.entity';
+import { CacheModule } from '../cache/cache.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Proposal, Vote]),
+    CacheModule,
+  ],
+  controllers: [GovernanceController],
+  providers: [GovernanceService, GovernanceCache],
+  exports: [GovernanceService],
+})
+export class GovernanceModule {}

--- a/src/governance/governance.service.spec.ts
+++ b/src/governance/governance.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GovernanceService } from './governance.service';
+import { GovernanceCache } from './governance.cache';
+import { Proposal, ProposalStatus, ProposalCategory, Vote } from './entities/proposal.entity';
+
+describe('GovernanceService', () => {
+  let service: GovernanceService;
+  let proposalRepo: jest.Mocked<Repository<Proposal>>;
+  let voteRepo: jest.Mocked<Repository<Vote>>;
+  let cache: jest.Mocked<GovernanceCache>;
+
+  beforeEach(async () => {
+    const mockProposalRepo = {
+      findOneBy: jest.fn(),
+      find: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      count: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const mockVoteRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    const mockCache = {
+      getProposal: jest.fn().mockResolvedValue(null),
+      setProposal: jest.fn(),
+      getActiveProposals: jest.fn().mockResolvedValue(null),
+      setActiveProposals: jest.fn(),
+      getStats: jest.fn().mockResolvedValue(null),
+      setStats: jest.fn(),
+      getVotes: jest.fn().mockResolvedValue(null),
+      setVotes: jest.fn(),
+      invalidateProposal: jest.fn(),
+      invalidateAll: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GovernanceService,
+        { provide: getRepositoryToken(Proposal), useValue: mockProposalRepo },
+        { provide: getRepositoryToken(Vote), useValue: mockVoteRepo },
+        { provide: GovernanceCache, useValue: mockCache },
+      ],
+    }).compile();
+
+    service = module.get<GovernanceService>(GovernanceService);
+    proposalRepo = module.get(getRepositoryToken(Proposal));
+    voteRepo = module.get(getRepositoryToken(Vote));
+    cache = module.get(GovernanceCache);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findOne', () => {
+    it('should return a proposal by id', async () => {
+      const mockProposal = { id: '1', title: 'Test' } as Proposal;
+      proposalRepo.findOneBy.mockResolvedValue(mockProposal);
+
+      const result = await service.findOne('1');
+      expect(result).toEqual(mockProposal);
+      expect(cache.setProposal).toHaveBeenCalledWith('1', mockProposal);
+    });
+
+    it('should return null if proposal not found', async () => {
+      proposalRepo.findOneBy.mockResolvedValue(null);
+
+      const result = await service.findOne('nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('should create a proposal', async () => {
+      const mockProposal = {
+        id: '1',
+        title: 'Test Proposal',
+        description: 'Test description',
+        proposer: '0x123',
+        category: ProposalCategory.PROTOCOL_UPGRADE,
+        status: ProposalStatus.PENDING,
+        metadata: {},
+      } as Proposal;
+      proposalRepo.create.mockReturnValue(mockProposal);
+      proposalRepo.save.mockResolvedValue(mockProposal);
+
+      const result = await service.create({
+        title: 'Test Proposal',
+        description: 'Test description',
+        proposer: '0x123',
+      });
+
+      expect(result).toEqual(mockProposal);
+      expect(cache.invalidateAll).toHaveBeenCalled();
+    });
+
+    it('should throw on empty title', async () => {
+      await expect(
+        service.create({ title: '', description: 'desc', proposer: '0x123' }),
+      ).rejects.toThrow('Proposal title is required');
+    });
+  });
+
+  describe('castVote', () => {
+    it('should cast a vote on an active proposal', async () => {
+      const mockProposal = {
+        id: '1',
+        status: ProposalStatus.ACTIVE,
+        totalVotes: 0,
+        votesFor: 0,
+        votesAgainst: 0,
+      } as Proposal;
+      proposalRepo.findOneBy.mockResolvedValue(mockProposal);
+      voteRepo.findOne.mockResolvedValue(null);
+      voteRepo.save.mockResolvedValue({} as Vote);
+      proposalRepo.save.mockResolvedValue(mockProposal);
+
+      const result = await service.castVote('1', '0x123', true);
+      expect(voteRepo.save).toHaveBeenCalled();
+      expect(mockProposal.totalVotes).toBe(1);
+      expect(mockProposal.votesFor).toBe(1);
+    });
+
+    it('should throw on duplicate vote', async () => {
+      const mockProposal = {
+        id: '1',
+        status: ProposalStatus.ACTIVE,
+      } as Proposal;
+      proposalRepo.findOneBy.mockResolvedValue(mockProposal);
+      voteRepo.findOne.mockResolvedValue({} as Vote);
+
+      await expect(
+        service.castVote('1', '0x123', true),
+      ).rejects.toThrow('already voted');
+    });
+  });
+});

--- a/src/governance/governance.service.ts
+++ b/src/governance/governance.service.ts
@@ -1,0 +1,343 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  Proposal,
+  ProposalStatus,
+  ProposalCategory,
+} from './entities/proposal.entity';
+import { Vote } from './entities/proposal.entity';
+import { GovernanceCache } from './governance.cache';
+
+export interface FindProposalsDto {
+  status?: ProposalStatus;
+  category?: ProposalCategory;
+  proposer?: string;
+  limit?: number;
+  offset?: number;
+  sort?: 'newest' | 'oldest' | 'most_votes' | 'highest_participation';
+}
+
+export interface PaginatedProposals {
+  items: Proposal[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface GovernanceStats {
+  totalProposals: number;
+  activeProposals: number;
+  participationRate: number;
+  averageQuorum: number;
+  proposalSuccessRate: number;
+}
+
+@Injectable()
+export class GovernanceService {
+  private readonly logger = new Logger(GovernanceService.name);
+
+  constructor(
+    @InjectRepository(Proposal)
+    private readonly proposalRepository: Repository<Proposal>,
+    @InjectRepository(Vote)
+    private readonly voteRepository: Repository<Vote>,
+    private readonly governanceCache: GovernanceCache,
+  ) {}
+
+  // ─── Proposals ──────────────────────────────────────────────────────────
+
+  async findOne(id: string): Promise<Proposal | null> {
+    const cached = await this.governanceCache.getProposal(id);
+    if (cached) return cached;
+
+    const proposal = await this.proposalRepository.findOneBy({ id });
+    if (proposal) {
+      await this.governanceCache.setProposal(id, proposal);
+    }
+    return proposal;
+  }
+
+  async create(data: {
+    title: string;
+    description: string;
+    proposer: string;
+    category?: ProposalCategory;
+    blockchainTxHash?: string;
+    metadata?: Record<string, any>;
+  }): Promise<Proposal> {
+    if (!data.title?.trim()) {
+      throw new BadRequestException('Proposal title is required');
+    }
+    if (!data.description?.trim()) {
+      throw new BadRequestException('Proposal description is required');
+    }
+    if (!data.proposer?.trim()) {
+      throw new BadRequestException('Proposer address is required');
+    }
+
+    const proposal = this.proposalRepository.create({
+      title: data.title.trim(),
+      description: data.description.trim(),
+      proposer: data.proposer.toLowerCase(),
+      category: data.category ?? ProposalCategory.PROTOCOL_UPGRADE,
+      status: ProposalStatus.PENDING,
+      blockchainTxHash: data.blockchainTxHash ?? null,
+      metadata: data.metadata ?? {},
+    });
+
+    const saved = await this.proposalRepository.save(proposal);
+    await this.governanceCache.invalidateAll();
+
+    this.logger.log(
+      `Proposal ${saved.id} created by ${saved.proposer} — category=${saved.category}`,
+    );
+    return saved;
+  }
+
+  async activate(id: string): Promise<Proposal> {
+    const proposal = await this.findOneOrThrow(id);
+
+    if (proposal.status !== ProposalStatus.PENDING) {
+      throw new BadRequestException(
+        `Cannot activate proposal ${id}: current status is ${proposal.status}`,
+      );
+    }
+
+    proposal.status = ProposalStatus.ACTIVE;
+    proposal.votingStartsAt = new Date();
+
+    const saved = await this.proposalRepository.save(proposal);
+    await this.governanceCache.invalidateProposal(id);
+
+    this.logger.log(`Proposal ${id} activated`);
+    return saved;
+  }
+
+  async execute(id: string): Promise<Proposal> {
+    const proposal = await this.findOneOrThrow(id);
+
+    if (proposal.status !== ProposalStatus.PASSED) {
+      throw new BadRequestException(
+        `Cannot execute proposal ${id}: current status is ${proposal.status}`,
+      );
+    }
+
+    proposal.status = ProposalStatus.EXECUTED;
+    proposal.executedAt = new Date();
+
+    const saved = await this.proposalRepository.save(proposal);
+    await this.governanceCache.invalidateProposal(id);
+
+    this.logger.log(`Proposal ${id} executed`);
+    return saved;
+  }
+
+  async cancel(id: string): Promise<Proposal> {
+    const proposal = await this.findOneOrThrow(id);
+
+    if (
+      proposal.status === ProposalStatus.EXECUTED ||
+      proposal.status === ProposalStatus.CANCELLED
+    ) {
+      throw new BadRequestException(
+        `Cannot cancel proposal ${id}: current status is ${proposal.status}`,
+      );
+    }
+
+    proposal.status = ProposalStatus.CANCELLED;
+
+    const saved = await this.proposalRepository.save(proposal);
+    await this.governanceCache.invalidateProposal(id);
+
+    this.logger.log(`Proposal ${id} cancelled`);
+    return saved;
+  }
+
+  async findAll(dto: FindProposalsDto = {}): Promise<PaginatedProposals> {
+    const {
+      status,
+      category,
+      proposer,
+      limit = 50,
+      offset = 0,
+      sort = 'newest',
+    } = dto;
+
+    if (limit < 1 || limit > 200) {
+      throw new BadRequestException('limit must be between 1 and 200');
+    }
+
+    const qb = this.proposalRepository
+      .createQueryBuilder('p')
+      .skip(offset)
+      .take(limit);
+
+    if (status) qb.andWhere('p.status = :status', { status });
+    if (category) qb.andWhere('p.category = :category', { category });
+    if (proposer) qb.andWhere('p.proposer = :proposer', { proposer: proposer.toLowerCase() });
+
+    switch (sort) {
+      case 'oldest':
+        qb.orderBy('p.createdAt', 'ASC');
+        break;
+      case 'most_votes':
+        qb.orderBy('p.totalVotes', 'DESC');
+        break;
+      case 'highest_participation':
+        qb.orderBy('p.participationRate', 'DESC');
+        break;
+      case 'newest':
+      default:
+        qb.orderBy('p.createdAt', 'DESC');
+        break;
+    }
+
+    const [items, total] = await qb.getManyAndCount();
+    return { items, total, limit, offset };
+  }
+
+  async findActive(): Promise<Proposal[]> {
+    const cached = await this.governanceCache.getActiveProposals();
+    if (cached) return cached;
+
+    const proposals = await this.proposalRepository.find({
+      where: { status: ProposalStatus.ACTIVE },
+      order: { createdAt: 'DESC' },
+    });
+
+    await this.governanceCache.setActiveProposals(proposals);
+    return proposals;
+  }
+
+  // ─── Voting ─────────────────────────────────────────────────────────────
+
+  async castVote(
+    proposalId: string,
+    voter: string,
+    support: boolean,
+    weight: number = 1,
+    metadata?: Record<string, any>,
+  ): Promise<Vote> {
+    const proposal = await this.findOneOrThrow(proposalId);
+
+    if (proposal.status !== ProposalStatus.ACTIVE) {
+      throw new BadRequestException(
+        `Cannot vote on proposal ${proposalId}: current status is ${proposal.status}`,
+      );
+    }
+
+    const existingVote = await this.voteRepository.findOne({
+      where: { proposalId, voter: voter.toLowerCase() },
+    });
+
+    if (existingVote) {
+      throw new ConflictException(
+        `Wallet ${voter} has already voted on proposal ${proposalId}`,
+      );
+    }
+
+    const vote = this.voteRepository.create({
+      proposalId,
+      voter: voter.toLowerCase(),
+      support,
+      weight,
+      metadata: metadata ?? {},
+    });
+
+    const saved = await this.voteRepository.save(vote);
+
+    // Update proposal vote counts
+    proposal.totalVotes += 1;
+    if (support) {
+      proposal.votesFor += 1;
+    } else {
+      proposal.votesAgainst += 1;
+    }
+
+    await this.proposalRepository.save(proposal);
+    await this.governanceCache.invalidateProposal(proposalId);
+
+    this.logger.log(
+      `Vote cast on proposal ${proposalId} by ${voter} — support=${support}`,
+    );
+    return saved;
+  }
+
+  async getVotesForProposal(proposalId: string): Promise<Vote[]> {
+    const cached = await this.governanceCache.getVotes(proposalId);
+    if (cached) return cached;
+
+    const votes = await this.voteRepository.find({
+      where: { proposalId },
+      order: { createdAt: 'DESC' },
+    });
+
+    await this.governanceCache.setVotes(proposalId, votes);
+    return votes;
+  }
+
+  // ─── Analytics ──────────────────────────────────────────────────────────
+
+  async getStats(): Promise<GovernanceStats> {
+    const cached = await this.governanceCache.getStats();
+    if (cached) return cached;
+
+    const totalProposals = await this.proposalRepository.count();
+
+    const activeProposals = await this.proposalRepository.count({
+      where: { status: ProposalStatus.ACTIVE },
+    });
+
+    const passedProposals = await this.proposalRepository.count({
+      where: { status: ProposalStatus.PASSED },
+    });
+
+    const executedProposals = await this.proposalRepository.count({
+      where: { status: ProposalStatus.EXECUTED },
+    });
+
+    const totalResolved = passedProposals + executedProposals;
+    const proposalSuccessRate =
+      totalProposals > 0 ? totalResolved / totalProposals : 0;
+
+    const allProposals = await this.proposalRepository.find();
+    const avgParticipation =
+      allProposals.length > 0
+        ? allProposals.reduce((sum, p) => sum + Number(p.participationRate), 0) /
+          allProposals.length
+        : 0;
+    const avgQuorum =
+      allProposals.length > 0
+        ? allProposals.reduce((sum, p) => sum + Number(p.quorumProgress), 0) /
+          allProposals.length
+        : 0;
+
+    const stats: GovernanceStats = {
+      totalProposals,
+      activeProposals,
+      participationRate: Number(avgParticipation.toFixed(4)),
+      averageQuorum: Number(avgQuorum.toFixed(4)),
+      proposalSuccessRate: Number(proposalSuccessRate.toFixed(4)),
+    };
+
+    await this.governanceCache.setStats(stats);
+    return stats;
+  }
+
+  // ─── Private helpers ────────────────────────────────────────────────────
+
+  private async findOneOrThrow(id: string): Promise<Proposal> {
+    const proposal = await this.findOne(id);
+    if (!proposal) {
+      throw new NotFoundException(`Proposal with ID ${id} not found`);
+    }
+    return proposal;
+  }
+}


### PR DESCRIPTION
## Summary

Implemented a production-ready Governance API following the existing project architecture and coding conventions.

### Changes

- Added `Proposal` and `Vote` entities with TypeORM, including proper indexing for query performance
- Implemented `GovernanceService` with proposal CRUD, voting, and analytics
- Added `GovernanceController` with full REST API endpoints (Swagger-documented)
- Integrated Redis caching via `GovernanceCache` for active proposals and statistics
- Added DTOs with `class-validator` and `@nestjs/swagger` decorators
- Included unit tests for `GovernanceService`
- Registered `GovernanceModule` in the main `AppModule`

### Endpoints

- `GET /governance/proposals` — List proposals with filtering and pagination
- `GET /governance/proposals/active` — Get active proposals
- `GET /governance/proposals/:id` — Get single proposal
- `POST /governance/proposals` — Create a new proposal
- `PATCH /governance/proposals/:id/activate` — Activate a pending proposal
- `PATCH /governance/proposals/:id/execute` — Execute a passed proposal
- `PATCH /governance/proposals/:id/cancel` — Cancel a proposal
- `GET /governance/proposals/:id/votes` — Get votes for a proposal
- `POST /governance/proposals/:id/votes` — Cast a vote
- `GET /governance/stats` — Get governance statistics

Closes #278
Closes #273
Closes #272
Closes #271